### PR TITLE
Fixing the fact that JS 'change' event isn't always fired.

### DIFF
--- a/src/Behat/Mink/Driver/Selenium2Driver.php
+++ b/src/Behat/Mink/Driver/Selenium2Driver.php
@@ -613,6 +613,26 @@ JS;
         $multipleJS   = $multiple ? 'true' : 'false';
 
         $script = <<<JS
+// Function to triger an event. Cross-browser compliant. See http://stackoverflow.com/a/2490876/135494
+var triggerEvent = function (element, eventName) {
+    var event;
+    if (document.createEvent) {
+        event = document.createEvent("HTMLEvents");
+        event.initEvent(eventName, true, true);
+    } else {
+        event = document.createEventObject();
+        event.eventType = eventName;
+    }
+
+    event.eventName = eventName;
+
+    if (document.createEvent) {
+        element.dispatchEvent(event);
+    } else {
+        element.fireEvent("on" + event.eventType, event);
+    }
+}
+
 var node = {{ELEMENT}}
 if (node.tagName == 'SELECT') {
     var i, l = node.length;
@@ -623,6 +643,8 @@ if (node.tagName == 'SELECT') {
             node[i].selected = false;
         }
     }
+    triggerEvent(node, 'change');
+
 } else {
     var nodes = window.document.getElementsByName(node.getAttribute('name'));
     var i, l = nodes.length;
@@ -633,6 +655,7 @@ if (node.tagName == 'SELECT') {
     }
 }
 JS;
+
 
         $this->executeJsOnXpath($xpath, $script);
     }


### PR DESCRIPTION
See [issue #255](https://github.com/Behat/Mink/pull/255) on Behat/Mink

The `change` isn't fired after selection an `<option>` in a `<select>`.

**Remark**: this should also be the case of the `<input type="checkbox" />` too, but I still haven't found a way to trigger the change event on those. Any ideas ?
