### PR TITLE
define the class attribute and create a getter for it

### DIFF
--- a/src/Behat/Mink/Driver/Selenium2Driver.php
+++ b/src/Behat/Mink/Driver/Selenium2Driver.php
@@ -105,6 +105,7 @@ class Selenium2Driver implements DriverInterface
     {
         return $this->wdSession;
     }
+
     /**
      * Returns the default capabilities
      *


### PR DESCRIPTION
If you want to use Mink with TestingBot (testingbot.com) you need to pass the Selenium Session ID to their Api so they can evaluate if the test has passed or not, to supply the test title, etc.

To get this session id I added a getter to avoid the hackish solution:

$this->getMink()->getSession("selenium2")->getDriver()->wdSession->getURL()

because the wdSession attribute is not defined but used and is therefore public

Greetings

Pascal Helfenstein
