### PR TITLE
Additional desired_capabilities for Selenium2 

### DIFF
--- a/src/Behat/Mink/Driver/Selenium2Driver.php
+++ b/src/Behat/Mink/Driver/Selenium2Driver.php
@@ -108,11 +108,14 @@ class Selenium2Driver implements DriverInterface
     public static function getDefaultCapabilities()
     {
         return array(
-            'browserName'    => 'firefox',
-            'version'        => '9',
-            'platform'       => 'ANY',
-            'browserVersion' => '9',
-            'browser'        => 'firefox'
+            'browserName'       => 'firefox',
+            'version'           => '9',
+            'platform'          => 'ANY',
+            'browserVersion'    => '9',
+            'browser'           => 'firefox',
+            'name'              => 'Behat Test',
+            'deviceOrientation' => 'portrait',
+            'deviceType'        => 'tablet'
         );
     }
 


### PR DESCRIPTION
 Added 3 desired capablities calld 'name' 'devive orientation' and 'deviceType'. It will help to run tests on Selenium Tests on iOS and Andriod devices. We can keep default value to null in case it affects browser tests. 
