### PR TITLE
Clean only text fields before setting a value

### DIFF
--- a/src/Behat/Mink/Driver/Selenium2Driver.php
+++ b/src/Behat/Mink/Driver/Selenium2Driver.php
@@ -410,7 +410,7 @@ class Selenium2Driver implements DriverInterface
     /**
      * Capture a screenshot of the current window.
      *
-     * @return  string  screenshot of MIME type image/* depending 
+     * @return  string  screenshot of MIME type image/* depending
      *   on driver (e.g., image/png, image/jpeg)
      */
     public function getScreenshot()
@@ -582,9 +582,10 @@ JS;
     public function setValue($xpath, $value)
     {
         $element = $this->wdSession->element('xpath', $xpath);
+        $elementname = strtolower($element->name());
         if (
-            strtolower($element->name()) != 'input' ||
-            strtolower($element->attribute('type')) != 'file'
+            $elementname == 'textarea' ||
+            ($elementname == 'input' && strtolower($element->attribute('type')) != 'file')
         )
         {
             $element->clear();


### PR DESCRIPTION
Hi,

setValue method clears the current value before setting the new one, but according to selenium2 docs (http://code.google.com/p/selenium/wiki/JsonWireProtocol#/session/:sessionId/element/:id/clear) only textarea and text elements can be cleared.

With the current implementation fillField (called from steps definitions like "I fill in the following:") also sends select fields through clear() this should not be a problem (Has no effect on other elements -> http://selenium.googlecode.com/svn/trunk/docs/api/java/org/openqa/selenium/WebElement.html#clear() ) but it does since I'm receiving a "Element must be user-editable in order to clear it.".

I've executed the MinkSelenium2Driver unit tests getting the same non-related failures before and after applying this patch.
