### PR TITLE
Made the driver use the Mink 1.5 CoreDriver

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
 
     "require": {
         "php":                       ">=5.3.1",
-        "behat/mink":                "~1.4.3",
+        "behat/mink":                "~1.5@dev",
         "instaclick/php-webdriver":  "~1.0.12"
     },
 
@@ -33,7 +33,7 @@
 
     "extra": {
         "branch-alias": {
-            "dev-master": "1.0.x-dev"
+            "dev-master": "1.1.x-dev"
         }
     }
 }

--- a/src/Behat/Mink/Driver/Selenium2Driver.php
+++ b/src/Behat/Mink/Driver/Selenium2Driver.php
@@ -4,8 +4,7 @@ namespace Behat\Mink\Driver;
 
 use Behat\Mink\Session,
     Behat\Mink\Element\NodeElement,
-    Behat\Mink\Exception\DriverException,
-    Behat\Mink\Exception\UnsupportedDriverActionException;
+    Behat\Mink\Exception\DriverException;
 
 use WebDriver\WebDriver,
     WebDriver\Exception\UnknownError;
@@ -23,7 +22,7 @@ use WebDriver\WebDriver,
  *
  * @author Pete Otaqui <pete@otaqui.com>
  */
-class Selenium2Driver implements DriverInterface
+class Selenium2Driver extends CoreDriver
 {
     /**
      * The current Mink session
@@ -352,38 +351,6 @@ class Selenium2Driver implements DriverInterface
     }
 
     /**
-     * Sets HTTP Basic authentication parameters
-     *
-     * @param   string|false    $user       user name or false to disable authentication
-     * @param   string          $password   password
-     */
-    public function setBasicAuth($user, $password)
-    {
-        throw new UnsupportedDriverActionException('Basic Auth is not supported by %s', $this);
-    }
-
-    /**
-     * Sets specific request header on client.
-     *
-     * @param   string  $name
-     * @param   string  $value
-     */
-    public function setRequestHeader($name, $value)
-    {
-        throw new UnsupportedDriverActionException('Request header is not supported by %s', $this);
-    }
-
-    /**
-     * Returns last response headers.
-     *
-     * @return  array
-     */
-    public function getResponseHeaders()
-    {
-        throw new UnsupportedDriverActionException('Response header is not supported by %s', $this);
-    }
-
-    /**
      * Sets cookie.
      *
      * @param   string  $name
@@ -421,16 +388,6 @@ class Selenium2Driver implements DriverInterface
                 return urldecode($cookie['value']);
             }
         }
-    }
-
-    /**
-     * Returns last response status code.
-     *
-     * @return  integer
-     */
-    public function getStatusCode()
-    {
-        throw new UnsupportedDriverActionException('Status code is not supported by %s', $this);
     }
 
     /**


### PR DESCRIPTION
@everzet currently, the driver is incompatible with Mink dev-develop as `~1.4.3` means `>=1.4.3,<1.5-dev` (the `~` operator allows bumping only the last part of the specified version number).
With my change, using the develop branch becomes required (note that the `@dev` flag is here to allow running the testsuite while Mink 1.5 is not released yet).

So you should tag a version of the driver before merging this.
