### PR TITLE
Change default name for resizeWindow

### DIFF
--- a/src/Behat/Mink/Driver/Selenium2Driver.php
+++ b/src/Behat/Mink/Driver/Selenium2Driver.php
@@ -912,6 +912,6 @@ JS;
      */
     public function resizeWindow($width, $height, $name = null)
     {
-        return $this->wdSession->window($name ? $name : '')->postSize(array('width' => $width, 'height' => $height));
+        return $this->wdSession->window($name ? $name : 'current')->postSize(array('width' => $width, 'height' => $height));
     }
 }


### PR DESCRIPTION
When using selenium2, the empty string paremeter works fine but when you use phantomjs/ghostdriver I had this error:

```
RouterReqHand - _handle - Thrown => {
  "message": "Request => {\"headers\":{\"Accept\":\"application/json;charset=UTF-8\",\"Content-Length\":\"27\",\"Content-Type\":\"application/json;charset=UTF-8\",\"Host\":\"localhost:8643\"},\"httpVersion\":\"1.1\",\"method\":\"POST\",\"post\":\"{\\\"width\\\":1024,\\\"height\\\":768}\",\"url\":\"/window/size\",\"urlParsed\":{\"anchor\":\"\",\"query\":\"\",\"file\":\"size\",\"directory\":\"/window/\",\"path\":\"/window/size\",\"relative\":\"/window/size\",\"port\":\"\",\"host\":\"\",\"password\":\"\",\"user\":\"\",\"userInfo\":\"\",\"authority\":\"\",\"protocol\":\"\",\"source\":\"/window/size\",\"queryKey\":{},\"chunks\":[\"window\",\"size\"]},\"urlOriginal\":\"/session/ed75cc50-a762-11e2-84ae-190f5150766e/window/size\"}",
  "name": "Missing Command Parameter",
  "line": 233,
  "sourceId": 158914992,
  "sourceURL": ":/ghostdriver/request_handlers/session_request_handler.js",
  "stack": "Missing Command Parameter"
```

From webdriver documentation, I saw that current parameter is used for the current page. By adding this parameter the driver works on Selenium2 and phantomjs/ghostdriver
