### PR TITLE
wait() bug

### DIFF
--- a/src/Behat/Mink/Driver/Selenium2Driver.php
+++ b/src/Behat/Mink/Driver/Selenium2Driver.php
@@ -937,7 +937,7 @@ JS;
 
         while (microtime(true) < $end && !$this->wdSession->execute(array('script' => $script, 'args' => array()))) {
             usleep(100000);
-	}
+        }
     }
 
     /**


### PR DESCRIPTION
Simplify the time calculations keeping the units in seconds.

Switch to usleep() because sleep(0.1) doesn't work as expected, i.e., sleep() expects the number of seconds as an integer.
