### PR TITLE
setValue() triggers 2 'onchange' events

### DIFF
--- a/src/Behat/Mink/Driver/Selenium2Driver.php
+++ b/src/Behat/Mink/Driver/Selenium2Driver.php
@@ -7,6 +7,7 @@ use Behat\Mink\Session,
     Behat\Mink\Exception\DriverException;
 
 use WebDriver\WebDriver;
+use WebDriver\Key;
 
 /*
  * This file is part of the Behat\Mink.
@@ -585,12 +586,17 @@ JS;
     {
         $element = $this->wdSession->element('xpath', $xpath);
         $elementname = strtolower($element->name());
-        if (
-            $elementname == 'textarea' ||
-            ($elementname == 'input' && strtolower($element->attribute('type')) != 'file')
-        )
-        {
-            $element->clear();
+
+        switch (true) {
+            case ($elementname == 'input' && strtolower($element->attribute('type')) == 'text'):
+                for ($i = 0; $i < strlen($element->attribute('value')); $i++) {
+                    $value = Key::BACKSPACE . $value;
+                }
+                break;
+            case ($elementname == 'textarea'):
+            case ($elementname == 'input' && strtolower($element->attribute('type')) != 'file'):
+                $element->clear();
+                break;
         }
 
         $element->value(array('value' => array($value)));


### PR DESCRIPTION
If you have a scenario where you have ajax triggering on a text field 'onchange' event. It can become a problem if the ajax disables the element until it's done. The setValue() method in the Selenium2Driver class calls clear() and then value() and both of them triggers an 'onchange' event in the browser.

I have modified this so that the setValue() does not clear() a text field but instead uses backspaces to clear the previous value, this way...the onchange event happens only once.
## Reason For Change:

If ajax disables a container upon change, it will cause a simple "I fill in" behat command to fail because when it calls clear() upon the field it triggers the change event...thus cause the value() method to fail due to a disabled element.
## Problematic Flow:

I fill in "Number" with "12345"
    Call to setValue()
    ---- Driver triggers clear()
    -------- Browser triggers onchange on the field
    ------------ Javascript disables the field waiting for ajax to complete
    ---- Driver triggers value()
    ---- Behat fails because the field is still disabled
## Solution:

I fill in "Number" with "12345"
    Call to setValue()
    ---- Driver calls attribute('value') to get the current value
    ---- Driver calculates the amount of backspaces needed to wipe out current value
    ---- Driver triggers value() with the amount of backspaces prepended to the new value
    ------- Browser triggers onchange
    ------------ Javascript disabled the field waiting for ajax
