### PR TITLE
Handles uncaught exception from WebDriver library on session opening

### DIFF
--- a/src/Behat/Mink/Driver/Selenium2Driver.php
+++ b/src/Behat/Mink/Driver/Selenium2Driver.php
@@ -259,7 +259,7 @@ class Selenium2Driver extends CoreDriver
         try {
             $this->wdSession = $this->webDriver->session($this->browserName, $this->desiredCapabilities);
         } catch (\Exception $e) {
-            throw new DriverException('Could not open connection');
+            throw new DriverException('Could not open connection', 0, $e);
         }
 
         if (!$this->wdSession) {
@@ -291,7 +291,7 @@ class Selenium2Driver extends CoreDriver
         try {
             $this->wdSession->close();
         } catch (\Exception $e) {
-            throw new DriverException('Could not close connection');
+            throw new DriverException('Could not close connection', 0, $e);
         }
     }
 


### PR DESCRIPTION
If attempt is made to connect to a host without running Selenium Grid, then `WebDriver` library exception is thrown instead of `DriverException`.

More details in connected issue.
