### PR TITLE
Force value to be string in setValue

### DIFF
--- a/src/Behat/Mink/Driver/Selenium2Driver.php
+++ b/src/Behat/Mink/Driver/Selenium2Driver.php
@@ -584,6 +584,7 @@ JS;
      */
     public function setValue($xpath, $value)
     {
+        $value = strval($value);
         $element = $this->wdSession->element('xpath', $xpath);
         $elementname = strtolower($element->name());
 


### PR DESCRIPTION
If you pass in an integer (possibly other types), the setValue does not work.
