### PR TITLE
setValue handles select fields

### DIFF
--- a/src/Behat/Mink/Driver/Selenium2Driver.php
+++ b/src/Behat/Mink/Driver/Selenium2Driver.php
@@ -600,6 +600,9 @@ JS;
             case ($elementname == 'input' && strtolower($element->attribute('type')) != 'file'):
                 $element->clear();
                 break;
+            case ($elementname == 'select'):
+                $this->selectOption($xpath, $value);
+                return;
         }
 
         $element->value(array('value' => array($value)));


### PR DESCRIPTION
Not sure how people feel about this one, but in my specific case at the time I call `setValue`, I don't know the element type.  It would be nice, since the driver does know, if the `setValue` function noticed if it was of type `select` and pass it on to the `selectOption` function.  Currently, it doesn't fail, it just doesn't work.
