### PR TITLE
Don't try and clear non-text/file inputs

### DIFF
--- a/src/Behat/Mink/Driver/Selenium2Driver.php
+++ b/src/Behat/Mink/Driver/Selenium2Driver.php
@@ -602,7 +602,6 @@ JS;
                 }
                 break;
             case ($elementname == 'textarea'):
-            case ($elementname == 'input' && strtolower($element->attribute('type')) != 'file'):
                 $element->clear();
                 break;
             case ($elementname == 'select'):


### PR DESCRIPTION
The existing code causes non `text`/`file` inputs to be cleared (eg `radio`), which results in a "Element must be user-editable in order to clear it" exception (see https://code.google.com/p/selenium/wiki/JsonWireProtocol#/session/:sessionId/element/:id/clear).

The line is redundant too, since `text` inputs are handled by the preceeding case.

(On a related note, I don't know what Selenium2 does with the new HTML5 inputs (`email`, `tel` etc), the docs _say_ `text` only, so this might affect them too.)
