### PR TITLE
setValue() clears text input incorrectly when caret gets to the beginning of the input on focus

### DIFF
--- a/src/Behat/Mink/Driver/Selenium2Driver.php
+++ b/src/Behat/Mink/Driver/Selenium2Driver.php
@@ -598,7 +598,7 @@ JS;
         switch (true) {
             case ($elementname == 'input' && strtolower($element->attribute('type')) == 'text'):
                 for ($i = 0; $i < strlen($element->attribute('value')); $i++) {
-                    $value = Key::BACKSPACE . $value;
+                    $value = Key::BACKSPACE . Key::DELETE . $value;
                 }
                 break;
             case ($elementname == 'textarea'):


### PR DESCRIPTION
Details are in issue https://github.com/Behat/MinkSelenium2Driver/issues/63
