### PR TITLE
Check/uncheck checkbox/radio button by clicking on it.

### DIFF
--- a/src/Behat/Mink/Driver/Selenium2Driver.php
+++ b/src/Behat/Mink/Driver/Selenium2Driver.php
@@ -622,9 +622,11 @@ JS;
      */
     public function check($xpath)
     {
-        $this->executeJsOnXpath($xpath, '{{ELEMENT}}.checked = true');
-        $script = "Syn.trigger('change', {}, {{ELEMENT}})";
-        $this->withSyn()->executeJsOnXpath($xpath, $script);
+        if ( $this->isChecked($xpath) ) {
+            return;
+        }
+
+        $this->click($xpath);
     }
 
     /**
@@ -634,9 +636,11 @@ JS;
      */
     public function uncheck($xpath)
     {
-        $this->executeJsOnXpath($xpath, '{{ELEMENT}}.checked = false');
-        $script = "Syn.trigger('change', {}, {{ELEMENT}})";
-        $this->withSyn()->executeJsOnXpath($xpath, $script);
+        if ( !$this->isChecked($xpath) ) {
+            return;
+        }
+
+        $this->click($xpath);
     }
 
     /**


### PR DESCRIPTION
Right now check/uncheck behaviour is emulated by:
1. setting `checked` attribute manually
2. firing `change` event manually

``` php
$this->executeJsOnXpath($xpath, '{{ELEMENT}}.checked = true');
$script = "Syn.trigger('change', {}, {{ELEMENT}})";
$this->withSyn()->executeJsOnXpath($xpath, $script);
```

This have several drawbacks:
1. `click` event isn't being triggered (user clicks on checkbox to change it's state)
2. if called several times a row, an emulated `change` event is triggered each time (doesn't happen when user is doing that)

I propose to use `isChecked` and `click` methods (of a driver) to simulate user behavior. I've checked, that when calling `click` method of `WebDriver` it does fire `change` and `click` events correctly.
