### PR TITLE
Add __clone, preps for new clean WedbDriver session

### DIFF
--- a/src/Behat/Mink/Driver/Selenium2Driver.php
+++ b/src/Behat/Mink/Driver/Selenium2Driver.php
@@ -73,6 +73,18 @@ class Selenium2Driver extends CoreDriver
     }
 
     /**
+     * Cleans up/prepares a new clone.
+     *
+     * After a clone, we break our reference to the "old" wdSession and create
+     * a new WebDriver.
+     */
+    public function __clone() {
+      $this->wdSession = NULL;
+      $this->started = false;
+      $this->setWebDriver(new WebDriver($this->webDriver->getURL()));
+    }
+
+    /**
      * Sets the browser name
      *
      * @param string $browserName the name of the browser to start, default is 'firefox'


### PR DESCRIPTION
This is the encapsulation-preserving iteration on #69 and #367 on Mink.

Basically, I think cloning a driver should be supported and create a distinct "browser head".

The "real world" of this is that with this change I have step definitions that are multi-persona aware. That is, I can write tests that involve "if brad posts this, kelly can see it", etc. without drastic logout/login sequences.
