### PR TITLE
Update Selenium server version, used in tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_script:
   - export DISPLAY=:99.0
   - sleep 4
 
-  - curl http://selenium.googlecode.com/files/selenium-server-standalone-2.31.0.jar > selenium.jar
+  - curl http://selenium.googlecode.com/files/selenium-server-standalone-2.35.0.jar > selenium.jar
   - java -jar selenium.jar > /dev/null &
   - sleep 4
 


### PR DESCRIPTION
Currently used version (2.31.0) doesn't properly work on newer version of Firefox browser (23+) and reports test passed, even though they are not.
