### PR TITLE
Use pure JavaScript code for node attribute retrieval

### DIFF
--- a/src/Behat/Mink/Driver/Selenium2Driver.php
+++ b/src/Behat/Mink/Driver/Selenium2Driver.php
@@ -528,10 +528,9 @@ class Selenium2Driver extends CoreDriver
      */
     public function getAttribute($xpath, $name)
     {
-        $attribute = $this->wdSession->element('xpath', $xpath)->attribute($name);
-        if ('' !== $attribute) {
-            return $attribute;
-        }
+        $script = 'return {{ELEMENT}}.getAttribute(' . json_encode((string)$name) . ')';
+
+        return $this->executeJsOnXpath($xpath, $script);
     }
 
     /**


### PR DESCRIPTION
Currently used `attribute` method of `WebDriver` works differently for `input` and `non-input` tags, when it comes to missing attribute querying (e.g. missing attribute value on `non-input` tag is returned as empty string, but for `input` tag `null` is returned instead). Therefore some workaround code was added, that considers empty attribute value as `null`, which in turn breaks whole logic of `hasAttribute` method (see https://github.com/Behat/Mink/issues/389).

This happens due fact, that according to some magic, that `WebDriver` is doing behind the scenes (see http://selenium.googlecode.com/svn/trunk/docs/api/java/org/openqa/selenium/WebElement.html#getAttribute(java.lang.String)) we might get JavaScript property value with same name instead of an expected attribute value.

Therefore I'm proposing to use pure `getAttribute` method of HTML nodes from JavaScript for node attribute retrieval.
