### PR TITLE
Use dev version of Mink during Travis testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ before_script:
   - sleep 4
 
   - curl http://getcomposer.org/installer | php
-  - php composer.phar install require behat/mink:~1.5@dev --prefer-source
+  - php composer.phar require behat/mink:~1.5@dev --prefer-source
 
   - sudo apt-get update > /dev/null
   - sudo apt-get install -y --force-yes apache2 libapache2-mod-php5 > /dev/null


### PR DESCRIPTION
Separating tests from a driver repo into a separate repo is great idea, when we're talking about code duplication. But isn't not that great idea, when to implement a feature a 2 different PR's are created for the driver repo and the Mink repo, where tests are added.

In such case Travis isn't aware of that and isn't including newly added tests in the build being tested.

I'm proposing to ease a situation a bit and reply on `~1.5@dev` version of `Mink` in Travis builds. This would allow build to include new tests as long as associated Mink's PR will be merged into `develop` branch before driver PR is tested.

I know, that due both processes (merging/testing) are asynchronous, that we might want to rerun tests on Travis side by hand, but it's still better then new tests not being executed at all.
