### PR TITLE
Use latest (v2.37) version of Selenium in Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_script:
   - export DISPLAY=:99.0
   - sleep 4
 
-  - curl http://selenium.googlecode.com/files/selenium-server-standalone-2.35.0.jar > selenium.jar
+  - curl http://selenium.googlecode.com/files/selenium-server-standalone-2.37.0.jar > selenium.jar
   - java -jar selenium.jar > /dev/null &
   - sleep 4
 


### PR DESCRIPTION
Use latest (v2.37) version of Selenium in Travis build just to make sure that all still works.
