### PR TITLE
PhantomJS failure debugging code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,12 +14,7 @@ before_script:
   - export WEB_FIXTURES_HOST=http://localhost
   - export WEB_FIXTURES_BROWSER=firefox
 
-  - sh -e /etc/init.d/xvfb start
-  - export DISPLAY=:99.0
-  - sleep 4
-
   - sh bin/run-"$WEBDRIVER".sh
-  - sleep 4
 
   - curl http://getcomposer.org/installer | php
   - php composer.phar install --prefer-source
@@ -30,3 +25,6 @@ before_script:
   - sudo /etc/init.d/apache2 restart
 
 script: phpunit -v
+
+after_failure:
+  - cat /tmp/webdriver_output.txt

--- a/bin/run-phantomjs.sh
+++ b/bin/run-phantomjs.sh
@@ -1,2 +1,5 @@
 #!/usr/bin/env sh
-phantomjs --webdriver=4444 > /dev/null &
+set -e
+
+phantomjs --version
+phantomjs --webdriver=4444 > /tmp/webdriver_output.txt &

--- a/bin/run-selenium.sh
+++ b/bin/run-selenium.sh
@@ -1,4 +1,9 @@
 #!/usr/bin/env sh
 set -e
+
+sh -e /etc/init.d/xvfb start
+export DISPLAY=:99.0
+sleep 4
+
 curl http://selenium.googlecode.com/files/selenium-server-standalone-2.37.0.jar > selenium.jar
-java -jar selenium.jar > /dev/null &
+java -jar selenium.jar > /tmp/webdriver_output.txt &


### PR DESCRIPTION
1. log WebDriver output and display it in case of error happens
2. move “frame buffer” initialization to Selenium-specific bootstrap
3. display PhantomJS version used on Travis

Related to #99
