### PR TITLE
Allow failures for PhantomJS on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ env:
 
 matrix:
   allow_failures:
-    - WEBDRIVER=phantomjs
+    - env: 'WEBDRIVER=phantomjs'
 
 before_script:
   - export WEB_FIXTURES_HOST=http://localhost


### PR DESCRIPTION
The webdriver implementation of PhantomJS suffers from some bugs currently
