### PR TITLE
Convert tag names to lowercase for comparisons in JS.

### DIFF
--- a/src/Behat/Mink/Driver/Selenium2Driver.php
+++ b/src/Behat/Mink/Driver/Selenium2Driver.php
@@ -581,10 +581,10 @@ class Selenium2Driver extends CoreDriver
     {
         $script = <<<JS
 var node = {{ELEMENT}},
-    tagName = node.tagName.toUpperCase(),
+    tagName = node.tagName.toLowerCase(),
     value = null;
 
-if (tagName == 'INPUT' || tagName == 'TEXTAREA') {
+if (tagName == 'input' || tagName == 'textarea') {
     var type = node.getAttribute('type');
     if (type == 'checkbox') {
         value = node.checked;
@@ -604,7 +604,7 @@ if (tagName == 'INPUT' || tagName == 'TEXTAREA') {
     } else {
         value = node.value;
     }
-} else if (tagName == 'SELECT') {
+} else if (tagName == 'select') {
     if (node.getAttribute('multiple')) {
         value = [];
         for (var i = 0; i < node.options.length; i++) {
@@ -740,8 +740,9 @@ var triggerEvent = function (element, eventName) {
     }
 };
 
-var node = {{ELEMENT}};
-if (node.tagName == 'SELECT') {
+var node = {{ELEMENT}},
+    tagName = node.tagName.toLowerCase();
+if (tagName == 'select') {
     var i, l = node.length;
     for (i = 0; i < l; i++) {
         if (node[i].value == $valueEscaped) {
@@ -760,7 +761,7 @@ if (node.tagName == 'SELECT') {
             node.checked = true;
         }
     }
-    if (node.tagName == 'INPUT') {
+    if (tagName == 'input') {
       var type = node.getAttribute('type');
       if (type == 'radio') {
         triggerEvent(node, 'change');


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | No additional failures, see note below |
| Fixed tickets | #105 |
| License | MIT |
| Doc PR | - |
### Notes

I couldn't get the tests to run with the version of Mink specified in the composer.json. I switched it to @dev and had to comment out line 115 in Selenium2DriverTest, `parent::testWindowMaximize();`. When I did this, I got the following results for Firefox.

```
Tests: 41, Assertions: 181, Incomplete: 1, Skipped: 2.
```

Incomplete: testMouseEvents
Skipped: testPatternGetWindowNames, testGetWindowName... skipped because `The "getWindowName method is not available for this session. Skipping this test.`

I got the same results when I apply the fix, so I would say the tests pass.
