### PR TITLE
Method for getting WebDriver’s Session ID

### DIFF
--- a/src/Behat/Mink/Driver/Selenium2Driver.php
+++ b/src/Behat/Mink/Driver/Selenium2Driver.php
@@ -913,4 +913,14 @@ JS;
     {
         $this->wdSession->window($name ? $name : 'current')->maximize();
     }
+
+    /**
+     * Returns Session ID of WebDriver or `null`, when session not started yet.
+     *
+     * @return string|null
+     */
+    public function getWebDriverSessionId()
+    {
+        return $this->isStarted() ? basename($this->wdSession->getUrl()) : null;
+    }
 }

--- a/tests/Behat/Mink/Driver/Selenium2DriverTest.php
+++ b/tests/Behat/Mink/Driver/Selenium2DriverTest.php
@@ -102,4 +102,14 @@ class Selenium2DriverTest extends JavascriptDriverTest
 
         $this->assertNotNull($element);
     }
+
+    public function testGetWebDriverSessionId()
+    {
+        /** @var Selenium2Driver $driver */
+        $driver = $this->getSession()->getDriver();
+        $this->assertNotEmpty($driver->getWebDriverSessionId(), 'Started session has an ID');
+
+        $driver = new Selenium2Driver();
+        $this->assertNull($driver->getWebDriverSessionId(), 'Not started session don\'t have an ID');
+    }
 }


### PR DESCRIPTION
Nowadays Selenium became so popular, that even hosted solutions with premade Selenium servers exists. Here are few examples:
- https://saucelabs.com/
- http://www.browserstack.com/

To interact with them through their API an ID of session, started using WebDriver protocol, is needed. For example we can update test status using it.

The code is pretty trivial: `$this->wdSession ? basename($this->wdSession->getUrl()) : '';` but to get the same from outside of a driver more code need to be written.

In this PR I've decided to simplify developers life, by adding `getSessionId` method to the driver.

@stof, I hope this PR can make it's way into upcoming release you're planning to make this weekend.
