### PR TITLE
Clean only text fields before setting a value - radios are being cleaned

### DIFF
--- a/src/Behat/Mink/Driver/Selenium2Driver.php
+++ b/src/Behat/Mink/Driver/Selenium2Driver.php
@@ -578,20 +578,20 @@ JS;
     {
         $value = strval($value);
         $element = $this->wdSession->element('xpath', $xpath);
-        $elementname = strtolower($element->name());
+        $elementName = strtolower($element->name());
         $elementType = strtolower($element->attribute('type'));
 
         switch (true) {
-            case ($elementname == 'input' && $elementType == 'text'):
+            case ($elementName == 'input' && $elementType == 'text'):
                 for ($i = 0; $i < strlen($element->attribute('value')); $i++) {
                     $value = Key::BACKSPACE . Key::DELETE . $value;
                 }
                 break;
-            case ($elementname == 'textarea'):
-            case ($elementname == 'input' && !in_array($elementType, array('file', 'radio'))):
+            case ($elementName == 'textarea'):
+            case ($elementName == 'input' && !in_array($elementType, array('file', 'radio'))):
                 $element->clear();
                 break;
-            case ($elementname == 'select'):
+            case ($elementName == 'select'):
                 $this->selectOption($xpath, $value);
 
                 return;


### PR DESCRIPTION
Hi,

Please see https://github.com/Behat/MinkSelenium2Driver/pull/29

This is an update for that issue to prevent radio elements from having clean() called on them during setValue(). 
