### PR TITLE
Removed manual change event triggering as stated in #80

### DIFF
--- a/src/Behat/Mink/Driver/Selenium2Driver.php
+++ b/src/Behat/Mink/Driver/Selenium2Driver.php
@@ -597,8 +597,6 @@ JS;
         }
 
         $element->value(array('value' => array($value)));
-        $script = "Syn.trigger('change', {}, {{ELEMENT}})";
-        $this->withSyn()->executeJsOnXpath($xpath, $script);
     }
 
     /**


### PR DESCRIPTION
Hi, In this update the manual change event triggering has been removed  as stated in #80 , here is the link of the comment suggesting that https://github.com/Behat/MinkSelenium2Driver/issues/80#issuecomment-28061785
