### PR TITLE
Simplified the Travis build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,14 @@ php: [5.3, 5.4, 5.5, 5.6, hhvm]
 
 env:
   - WEBDRIVER=selenium
-  - WEBDRIVER=phantomjs
 
 matrix:
   allow_failures:
     - env: 'WEBDRIVER=phantomjs'
   fast_finish: true
+  include:
+    - php: 5.5
+      env: WEBDRIVER=phantomjs
 
 before_script:
   - export WEB_FIXTURES_HOST=http://localhost

--- a/bin/run-phantomjs.sh
+++ b/bin/run-phantomjs.sh
@@ -2,4 +2,5 @@
 set -e
 
 phantomjs --version
+echo '    Running PhantomJS'
 phantomjs --webdriver=4444 > /tmp/webdriver_output.txt &


### PR DESCRIPTION
The PhantomJS implementation does not need to run against all PHP versions. Using a single version is enough to verify the behavior given that it does not depend on PHP itself.
This will make the build faster by removing 4 jobs from the matrix.
