### PR TITLE
Refactor the driver to optimize xpath search

### DIFF
--- a/src/Behat/Mink/Driver/Selenium2Driver.php
+++ b/src/Behat/Mink/Driver/Selenium2Driver.php
@@ -790,8 +790,7 @@ JS;
     public function rightClick($xpath)
     {
         $this->mouseOver($xpath);
-        $script = 'Syn.rightClick({{ELEMENT}})';
-        $this->withSyn()->executeJsOnXpath($xpath, $script);
+        $this->wdSession->click(array('button' => 2));
     }
 
     /**


### PR DESCRIPTION
The goal here is to avoid doing the same XPath searches many times when performing an action by reusing the same WebElement instance whenever possible.
