### PR TITLE
Added the support of multiple select boxes in setValue

### DIFF
--- a/src/Behat/Mink/Driver/Selenium2Driver.php
+++ b/src/Behat/Mink/Driver/Selenium2Driver.php
@@ -615,6 +615,16 @@ JS;
         $elementName = strtolower($element->name());
 
         if ('select' === $elementName) {
+            if (is_array($value)) {
+                $this->deselectAllOptions($element);
+
+                foreach ($value as $option) {
+                    $this->selectOptionOnElement($element, $option, true);
+                }
+
+                return;
+            }
+
             $this->selectOptionOnElement($element, $value);
 
             return;
@@ -1013,6 +1023,19 @@ JS;
         }
 
         // Deselect all options before selecting the new one
+        $this->deselectAllOptions($element);
+        $option->click();
+    }
+
+    /**
+     * Deselects all options of a multiple select
+     *
+     * Note: this implementation does not trigger a change event after deselecting the elements.
+     *
+     * @param Element $element
+     */
+    private function deselectAllOptions(Element $element)
+    {
         $script = <<<JS
 var node = {{ELEMENT}};
 var i, l = node.options.length;
@@ -1022,7 +1045,6 @@ for (i = 0; i < l; i++) {
 JS;
 
         $this->executeJsOnElement($element, $script);
-        $option->click();
     }
 
     /**


### PR DESCRIPTION
Note that there is several ways this could be implemented:
1. deselecting everything in JS (without change event) and then selecting the options we need (with a change event for each of them triggered by Selenium)
2. doing a diff of the currently selected options and the expected ones and then selecting/unselecting the needed ones (with a change event triggered by Selenium for each modifications)
3. determining all the actions to do in the diff (same than option 2), doing all of them except one in JS (without change event) and doing the last one through Selenium (to trigger a single change event)

All options have their pros and cons regarding the change event (and the most realistic one depends of the way the browser implements its UI for multiple select boxes, which is different for desktop browsers and mobile browsers for instance).
For the sake of simplicity (reusing the code we already have), I went for option 1, even if it misses a change event when deselecting everything and triggers multiple change events when selecting the current values.
