### PR TITLE
Fixed the implementation of click to block until the page is loaded

### DIFF
--- a/src/Behat/Mink/Driver/Selenium2Driver.php
+++ b/src/Behat/Mink/Driver/Selenium2Driver.php
@@ -750,7 +750,7 @@ JS;
     private function clickOnElement(Element $element)
     {
         $this->wdSession->moveto(array('element' => $element->getID()));
-        $this->wdSession->click(array('button' => 0));
+        $element->click();
     }
 
     /**


### PR DESCRIPTION
When upgrading the driver in my work project from d97f184aa1ebefe44c0f091ff39204ea7ef21f52 to the current master, the login in my app broke, because it gave the control back to Behat before the form login submission was complete, thus trying to go on other pages before the session cookie was available.
Changing the click back from a session click at the position of the mouse to a click on the element fixed the blocking behavior of the action. This is hard to understand, because the click action was still happening on the right element.
I tried writing a test to cover this, but I failed at building a testcase reproducing the same behavior.
