### PR TITLE
Add support for chromeOptions argument.

### DIFF
--- a/src/Behat/Mink/Driver/Selenium2Driver.php
+++ b/src/Behat/Mink/Driver/Selenium2Driver.php
@@ -126,10 +126,21 @@ class Selenium2Driver extends CoreDriver
             unset($desiredCapabilities['firefox']);
         }
 
+        // See https://sites.google.com/a/chromium.org/chromedriver/capabilities
         if (isset($desiredCapabilities['chrome'])) {
+
+            $chromeOptions = array();
+
             foreach ($desiredCapabilities['chrome'] as $capability => $value) {
+                if ($capability == 'switches') {
+                    $chromeOptions['args'] = $value;
+                } else {
+                    $chromeOptions[$capability] = $value;
+                }
                 $desiredCapabilities['chrome.'.$capability] = $value;
             }
+
+            $desiredCapabilities['chromeOptions'] = $chromeOptions;
 
             unset($desiredCapabilities['chrome']);
         }


### PR DESCRIPTION
Hello, 

The command-line options `chrome.switches`, `chrome.extensions` and `chrome.binary` are not supported anymore by latest versions of ChromeDriver (see [Capabilities (aka ChromeOptions)](https://sites.google.com/a/chromium.org/chromedriver/capabilities)). 

Tested using Chrome 35 and ChromeDriver 2.10.

I noticed that while trying to set the `--test-type` flag, to avoid a warning displayed when Chrome is launched with the `--ignore-certificate-errors` flag. 

The following configuration was not working: 

```
extensions:
        Behat\MinkExtension\Extension:
            selenium2:
                capabilities:
                    chrome:
                        switches: ["--start-maximized", "--test-type"]
```

My change is backward compatible because it just adds a `chromeOptions` key to the desired capabilities. Other `chrome.*` keys are just ignored so it's fine. 

This is actually a fix, as to be more flexible it would be nice to support all the keys of ChromeOptions, but this also needs a change in MinkExtension. 

**Related issues**:
- #174
