### PR TITLE
add moveTo and click without a element; mouseOver with x and y coordinat...

### DIFF
--- a/src/Behat/Mink/Driver/Selenium2Driver.php
+++ b/src/Behat/Mink/Driver/Selenium2Driver.php
@@ -812,7 +812,7 @@ JS;
     }
 
     /**
-     * {@inheritdoc}
+     * Move the cursor to specific position
      */
     public function moveCursorTo($x, $y)
     {
@@ -823,7 +823,7 @@ JS;
     }
 
     /**
-     * {@inheritdoc}
+     * Perform click on cursor position
      */
     public function clickAtCursor()
     {
@@ -831,7 +831,7 @@ JS;
     }
 
     /**
-     * {@inheritdoc}
+     * Perform double click on cursor position
      */
     public function doubleClickAtCursor()
     {
@@ -839,7 +839,7 @@ JS;
     }
 
     /**
-     * {@inheritdoc}
+     * Perform right click on cursor position
      */
     public function rightClickAtCursor()
     {


### PR DESCRIPTION
Adds the    possibility to work without elements just with coordinates.
- Add  `moveTo`
- Add x and y coordinates to `mouseOver`
- Change click events to work without elements

Refs https://github.com/Behat/Mink/pull/596
