### PR TITLE
Fix Selenium2 Driver dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
 
     "require": {
         "php":                       ">=5.3.1",
-        "behat/mink":                "~1.6@dev",
+        "behat/mink":                "1.6.x-dev",
         "instaclick/php-webdriver":  "~1.1"
     },
 


### PR DESCRIPTION
```
  Problem 1
    - Installation request for behat/mink-selenium2-driver 1.2.x-dev -> satisfiable by behat/mink-selenium2-driver[1.2.x-dev].
    - behat/mink-selenium2-driver 1.2.x-dev requires behat/mink ~1.6@dev -> no matching package found.
```
