### PR TITLE
Fix the window name test for the chrome driver

### DIFF
--- a/tests/Custom/WindowNameTest.php
+++ b/tests/Custom/WindowNameTest.php
@@ -6,7 +6,7 @@ use Behat\Mink\Tests\Driver\TestCase;
 
 class WindowNameTest extends TestCase
 {
-    const WINDOW_NAME_REGEXP = '/[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}/';
+    const WINDOW_NAME_REGEXP = '/[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}/i';
 
     public function testPatternGetWindowNames()
     {


### PR DESCRIPTION
While the Firefox driver uses lowercase letters, the Chrome driver is using uppercase letters in the window name (yeah, I started running the testsuite with chromium rather than using firefox because of the Firefox 35 issue).