### PR TITLE
Fixed dropTo() drop behaviour

### DIFF
--- a/src/Behat/Mink/Driver/Selenium2Driver.php
+++ b/src/Behat/Mink/Driver/Selenium2Driver.php
@@ -887,7 +887,6 @@ JS;
         $this->wdSession->moveto(array(
             'element' => $destination->getID()
         ));
-        $this->wdSession->buttonup();
 
         $script = <<<JS
 (function (element) {
@@ -900,6 +899,8 @@ JS;
 }({{ELEMENT}}));
 JS;
         $this->withSyn()->executeJsOnElement($destination, $script);
+        
+        $this->wdSession->buttonup();
     }
 
     /**


### PR DESCRIPTION
At the moment !this->wdSession()->buttonup() is  called before the javascript is prepared and executed, what caused the dropping to fail.

Closes #20