### PR TITLE
Fix comment for setTimeouts

### DIFF
--- a/src/Selenium2Driver.php
+++ b/src/Selenium2Driver.php
@@ -299,7 +299,7 @@ class Selenium2Driver extends CoreDriver
     /**
      * Sets the timeouts to apply to the webdriver session
      *
-     * @param array $timeouts The session timeout settings: Array of {script, implicit, page} => time in microsecconds
+     * @param array $timeouts The session timeout settings: Array of {script, implicit, page} => time in milliseconds
      *
      * @throws DriverException
      */


### PR DESCRIPTION
Timeouts are in milliseconds, rather than microseconds.
Milliseconds are defined here: https://github.com/instaclick/php-webdriver/blob/master/lib/WebDriver/Session.php#L320