### PR TITLE
Switch to the container-based infrastructure on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,11 @@
 language: php
 
+sudo: false
+
+cache:
+  directories:
+    - $HOME/.composer/cache
+
 php: [5.3, 5.4, 5.5, 5.6, hhvm]
 
 env:
@@ -17,17 +23,15 @@ matrix:
       env: WEBDRIVER=phantomjs PHANTOM_VERSION=2
 
 before_script:
-  - export WEB_FIXTURES_HOST=http://localhost
+  - export WEB_FIXTURES_HOST=http://localhost:8000
   - export WEB_FIXTURES_BROWSER=firefox
 
   - sh bin/run-"$WEBDRIVER".sh
 
   - composer install --prefer-source
 
-  - sudo apt-get update > /dev/null
-  - sudo apt-get install -y --force-yes apache2 libapache2-mod-php5 > /dev/null
-  - sudo sed -i -e "s,/var/www,$(pwd)/vendor/behat/mink/driver-testsuite/web-fixtures,g" /etc/apache2/sites-available/default
-  - sudo /etc/init.d/apache2 restart
+  # Start a webserver for web fixtures. Force using PHP 5.6 to be able to run it on PHP 5.3 and HHVM jobs too
+  - ~/.phpenv/versions/5.6/bin/php -S localhost:8000 -t vendor/behat/mink/driver-testsuite/web-fixtures > /dev/null 2>&1 &
 
 script: phpunit -v --coverage-clover=coverage.clover
 


### PR DESCRIPTION
This uses the PHP builtin webserver to expose web fixtures rather than installing Apache. This relies on the fact that PHP 5.6 is installed on Travis even on jobs running with a different version, and so can be used for fixtures on all jobs (and we don't care about the PHP version used to run fixtures as we were not using the Travis one before anyway).

If this works fine, I will apply it on other driver repositories needing a webserver to expose fixtures (i.e. all except BrowserKitDriver)