### PR TITLE
Add vendor binaries to composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,8 @@
             "Behat\\Mink\\Tests\\Driver\\": "tests"
         }
     },
+    
+    "bin": {"bin/run-phantomjs.sh", "bin/run-selenium.sh"},
 
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
This lists the "run-phantomjs" and "run-selenium" commands as vendor binaries in composer.json in order to be passed along to a user who installs the package