### PR TITLE
Clear `input` and `textarea` on `setValue`

### DIFF
--- a/src/Selenium2Driver.php
+++ b/src/Selenium2Driver.php
@@ -657,9 +657,15 @@ JS;
 
         if (in_array($elementName, array('input', 'textarea'))) {
             $existingValueLength = strlen($element->attribute('value'));
+            $deleteAndBackspace = Key::DELETE . Key::BACKSPACE;
+
+            for($i = 0; $i < $existingValueLength; $i++) {
+                $element->postValue(array('value' => array($deleteAndBackspace)));
+            }
+
             // Add the TAB key to ensure we unfocus the field as browsers are triggering the change event only
             // after leaving the field.
-            $value = str_repeat(Key::BACKSPACE . Key::DELETE, $existingValueLength) . $value . Key::TAB;
+            $value = $value . Key::TAB;
         }
 
         $element->postValue(array('value' => array($value)));

--- a/src/Selenium2Driver.php
+++ b/src/Selenium2Driver.php
@@ -655,8 +655,9 @@ JS;
 
         $value = strval($value);
 
-        if (in_array($elementName, array('input', 'textarea'))) {
-            $existingValueLength = strlen($element->attribute('value'));
+        $existingValueLength = strlen($element->attribute('value'));
+        $clearInputOrTextArea = $existingValueLength > 0 && in_array($elementName, array('input', 'textarea'));
+        if ($clearInputOrTextArea) {
             $deleteAndBackspace = Key::DELETE . Key::BACKSPACE;
 
             for($i = 0; $i < $existingValueLength; $i++) {


### PR DESCRIPTION
I had similar issues as described in #198, this should fix it and delete every character in the input or textarea.

- Send `Delete`- and `Backspace`-Keystrokes for every Character
  in the Input or Textarea
- Previous behaviour which sent all deletions + given value in
  one String didn't work
