### PR TITLE
Update the testsuite to use the new mink/driver-testsuite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ cache:
   directories:
     - $HOME/.composer/cache/files
 
-php: [5.3, 5.4, 5.5, 5.6, 7.0, hhvm]
+php: [5.3, 5.4, 5.5, 5.6, 7.0, 7.1, hhvm]
 
 env:
   - WEBDRIVER=selenium
@@ -23,15 +23,12 @@ matrix:
       env: WEBDRIVER=phantomjs PHANTOM_VERSION=2
 
 before_script:
-  - export WEB_FIXTURES_HOST=http://localhost:8000
-  - export WEB_FIXTURES_BROWSER=firefox
-
   - sh bin/run-"$WEBDRIVER".sh
 
   - composer install --prefer-source
 
   # Start a webserver for web fixtures. Force using PHP 5.6 to be able to run it on PHP 5.3 and HHVM jobs too
-  - ~/.phpenv/versions/5.6/bin/php -S localhost:8000 -t vendor/behat/mink/driver-testsuite/web-fixtures > /dev/null 2>&1 &
+  - MINK_PHP_BIN=~/.phpenv/versions/5.6/bin/php vendor/bin/mink-test-server > /dev/null 2>&1 &
 
 script: phpunit -v --coverage-clover=coverage.clover
 

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     },
 
     "require-dev": {
-        "symfony/phpunit-bridge": "~2.7"
+        "mink/driver-testsuite": "dev-master"
     },
 
     "autoload": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<phpunit colors="true" bootstrap="vendor/behat/mink/driver-testsuite/bootstrap.php">
+<phpunit colors="true" bootstrap="vendor/autoload.php">
     <testsuites>
         <testsuite name="Driver test suite">
             <directory>tests</directory>

--- a/tests/Selenium2Config.php
+++ b/tests/Selenium2Config.php
@@ -16,7 +16,7 @@ class Selenium2Config extends AbstractConfig
      */
     public function createDriver()
     {
-        $browser = $_SERVER['WEB_FIXTURES_BROWSER'];
+        $browser = getenv('WEB_FIXTURES_BROWSER') ?: 'firefox';
         $seleniumHost = $_SERVER['DRIVER_URL'];
 
         return new Selenium2Driver($browser, null, $seleniumHost);


### PR DESCRIPTION
This updates the testsuite to use https://github.com/minkphp/driver-testsuite

TODOs:
- [x] change the composer requirements once https://github.com/minkphp/driver-testsuite/pull/1 is merged