### PR TITLE
Fix the path to tests

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -4,7 +4,7 @@
     <testsuites>
         <testsuite name="Driver test suite">
             <directory>tests</directory>
-            <directory>vendor/behat/mink/driver-testsuite/tests</directory>
+            <directory>vendor/mink/driver-testsuite/tests</directory>
         </testsuite>
     </testsuites>
 


### PR DESCRIPTION
They should reference the new driver-testsuite package, not the old testsuite available in Mink, as it will be removed.