### PR TITLE
Implement type() method to use Syn.type. Fixed issue with key{press|d…

### DIFF
--- a/src/Selenium2Driver.php
+++ b/src/Selenium2Driver.php
@@ -863,6 +863,21 @@ JS;
     }
 
     /**
+     * Simulates keyboard typing with Syn.type().
+     * See: https://github.com/bitovi/syn/blob/master/src/key.js#L133
+     *
+     * @param string     $xpath
+     * @param string     $text  example: "Firstname\tLast\tmail@example.org\r"
+     *
+     */
+    public function type($xpath, $text)
+    {
+      $text = json_encode($text);
+      $script = "Syn.type({{ELEMENT}}, $text)";
+      $this->withSyn()->executeJsOnXpath($xpath, $script);
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function dragTo($sourceXpath, $destinationXpath)


### PR DESCRIPTION
…own|up} not working on non-input elements.
