### PR TITLE
Improve compatibility with GeckoDriver when using Selenium 3

### DIFF
--- a/src/Selenium2Driver.php
+++ b/src/Selenium2Driver.php
@@ -14,6 +14,7 @@ use Behat\Mink\Exception\DriverException;
 use Behat\Mink\Selector\Xpath\Escaper;
 use WebDriver\Element;
 use WebDriver\Exception\NoSuchElement;
+use WebDriver\Exception\UnknownCommand;
 use WebDriver\Exception\UnknownError;
 use WebDriver\Exception;
 use WebDriver\Key;
@@ -764,7 +765,13 @@ JS;
 
     private function clickOnElement(Element $element)
     {
-        $this->wdSession->moveto(array('element' => $element->getID()));
+        try {
+            // Move the mouse to the element as Selenium does not allow clicking on an element which is outside the viewport
+            $this->wdSession->moveto(array('element' => $element->getID()));
+        } catch (UnknownCommand $e) {
+            // If the Webdriver implementation does not support moveto (which is not part of the W3C WebDriver spec), proceed to the click
+        }
+
         $element->click();
     }
 


### PR DESCRIPTION
moveto is not part of the W3C Webdriver spec, and so GeckoDriver does not implement it.
Our click() implementation uses it to ensure that the element is scrolled into the viewport before clicking on it, due to Selenium requirements.
Instead of forbidding the click entirely when using Geckodriver, this now attempts the click directly when moving is unsupported, hoping that the driver has not implemented the restriction when they don't have a way to force the move yet.

Refs #254

Other methods using ``moveto`` are not changed like this as they rely on the cursor position too (when using other non-standardized APIs).

Before:
Tests: 171, Assertions: 300, Errors: 46, Failures: 4, Skipped: 14.

After:
Tests: 172, Assertions: 375, Errors: 11, Failures: 6, Skipped: 13.

(and one of the failures and one of the errors are the one from #239)