### PR TITLE
Fix the window name tests for GeckoDriver

### DIFF
--- a/tests/Custom/WindowNameTest.php
+++ b/tests/Custom/WindowNameTest.php
@@ -6,7 +6,7 @@ use Behat\Mink\Tests\Driver\TestCase;
 
 class WindowNameTest extends TestCase
 {
-    const WINDOW_NAME_REGEXP = '/[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}/i';
+    const WINDOW_NAME_REGEXP = '/(?:[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}|^\d++$)/i';
 
     public function testPatternGetWindowNames()
     {


### PR DESCRIPTION
GeckoDriver does not put a UUID in its window names.