### PR TITLE
Fix the usage of the composer cache on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ matrix:
 before_script:
   - sh bin/run-"$WEBDRIVER".sh
 
-  - composer install --prefer-source
+  - composer install
 
   # Start a webserver for web fixtures. Force using PHP 5.6 to be able to run it on PHP 5.3 and HHVM jobs too
   - MINK_PHP_BIN=~/.phpenv/versions/5.6/bin/php vendor/bin/mink-test-server > /dev/null 2>&1 &


### PR DESCRIPTION
Forcing a source install made the persistence of the composer download cache between builds useless, as we don't download packages.

No other (maintained) Mink repository is using ``--prefer-source`` on Travis. This one should not either.