### PR TITLE
Removes useless default capabilities

### DIFF
--- a/src/Selenium2Driver.php
+++ b/src/Selenium2Driver.php
@@ -189,14 +189,9 @@ class Selenium2Driver extends CoreDriver
     {
         return array(
             'browserName'       => 'firefox',
-            'version'           => '9',
+            'version'           => '',
             'platform'          => 'ANY',
-            'browserVersion'    => '9',
-            'browser'           => 'firefox',
-            'name'              => 'Behat Test',
-            'deviceOrientation' => 'portrait',
-            'deviceType'        => 'tablet',
-            'selenium-version'  => '2.31.0'
+            'name'              => 'Behat Test'
         );
     }
 


### PR DESCRIPTION
Applying the same reasoning as Behat/MinkExtension#186, there are a few
default capabilities that are pretty useless and thus should not be merged
into the `desiredCapabilities` in the general use case. So let's remove
them. :)