### PR TITLE
Clean default capabilities

### DIFF
--- a/src/Selenium2Driver.php
+++ b/src/Selenium2Driver.php
@@ -189,14 +189,7 @@ class Selenium2Driver extends CoreDriver
     {
         return array(
             'browserName'       => 'firefox',
-            'version'           => '9',
-            'platform'          => 'ANY',
-            'browserVersion'    => '9',
-            'browser'           => 'firefox',
             'name'              => 'Behat Test',
-            'deviceOrientation' => 'portrait',
-            'deviceType'        => 'tablet',
-            'selenium-version'  => '2.31.0'
         );
     }
 


### PR DESCRIPTION
Setting capabilities specifying a firefox version or a selenium version by default breaks when running against a server being strict about the requested capabilities (as it is unlikely to run Firefox 9 these days).
Note that I faced this issue when trying to run tests against geckodriver (as it is strict about respecting the Firefox version, unlike the old FirefoxDriver of Selenium 2).