### PR TITLE
Rewrite the capability test to be compatible with lazy-starting

### DIFF
--- a/tests/Custom/DesiredCapabilitiesTest.php
+++ b/tests/Custom/DesiredCapabilitiesTest.php
@@ -44,7 +44,9 @@ class DesiredCapabilitiesTest extends TestCase
             'deviceType'        => 'tablet',
             'selenium-version'  => '2.45.0'
         );
-        $driver = $this->getSession()->getDriver();
+        $session = $this->getSession();
+        $session->start();
+        $driver = $session->getDriver();
         $driver->setDesiredCapabilities($caps);
     }
 }

--- a/tests/Custom/WebDriverTest.php
+++ b/tests/Custom/WebDriverTest.php
@@ -9,8 +9,10 @@ class WebDriverTest extends TestCase
 {
     public function testGetWebDriverSessionId()
     {
+        $session = $this->getSession();
+        $session->start();
         /** @var Selenium2Driver $driver */
-        $driver = $this->getSession()->getDriver();
+        $driver = $session->getDriver();
         $this->assertNotEmpty($driver->getWebDriverSessionId(), 'Started session has an ID');
 
         $driver = new Selenium2Driver();

--- a/tests/Custom/WindowNameTest.php
+++ b/tests/Custom/WindowNameTest.php
@@ -11,6 +11,7 @@ class WindowNameTest extends TestCase
     public function testPatternGetWindowNames()
     {
         $session = $this->getSession();
+        $session->start();
 
         $windowNames = $session->getWindowNames();
         $this->assertArrayHasKey(0, $windowNames);
@@ -23,6 +24,7 @@ class WindowNameTest extends TestCase
     public function testGetWindowName()
     {
         $session = $this->getSession();
+        $session->start();
 
         $this->assertRegExp(self::WINDOW_NAME_REGEXP, $session->getWindowName());
     }


### PR DESCRIPTION
The session is not started anymore when getting it in the test. It requires starting it explicitly to test the case of setting capabilities after starting.