### PR TITLE
Rewrite the window name tests to avoid forcing a pattern

### DIFF
--- a/tests/Custom/WindowNameTest.php
+++ b/tests/Custom/WindowNameTest.php
@@ -6,9 +6,7 @@ use Behat\Mink\Tests\Driver\TestCase;
 
 class WindowNameTest extends TestCase
 {
-    const WINDOW_NAME_REGEXP = '/(?:[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}|^\d++$)/i';
-
-    public function testPatternGetWindowNames()
+    public function testWindowNames()
     {
         $session = $this->getSession();
         $session->start();
@@ -16,16 +14,9 @@ class WindowNameTest extends TestCase
         $windowNames = $session->getWindowNames();
         $this->assertArrayHasKey(0, $windowNames);
 
-        foreach ($windowNames as $name) {
-            $this->assertRegExp(self::WINDOW_NAME_REGEXP, $name);
-        }
-    }
+        $windowName = $session->getWindowName();
 
-    public function testGetWindowName()
-    {
-        $session = $this->getSession();
-        $session->start();
-
-        $this->assertRegExp(self::WINDOW_NAME_REGEXP, $session->getWindowName());
+        $this->assertInternalType('string', $windowName);
+        $this->assertContains($windowName, $windowNames, 'The current window name is one of the available window names.');
     }
 }


### PR DESCRIPTION
Selenium defines the window name as a opaque string, so each browser is free to use anything they want. And this changed over time, causing the UUID regex to break even for browsers using a UUID in the past (Chrome adds more things around the UUID for instance).