### PR TITLE
Fix some Travis issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ cache:
   directories:
     - $HOME/.composer/cache/files
 
-php: [5.3, 5.4, 5.5, 5.6, 7.0, 7.1, hhvm]
+php: [5.4, 5.5, 5.6, 7.0, 7.1, 7.2]
 
 env:
   - WEBDRIVER=selenium
@@ -19,14 +19,18 @@ matrix:
       sudo: required
       services:
         - docker
+    - php: 5.3
+      dist: precise
+      # Force using PHP 5.6 for the test server as PHP 5.3 does not have the builtin webserver
+      env: MINK_PHP_BIN=~/.phpenv/versions/5.6/bin/php
 
 before_script:
   - sh bin/run-"$WEBDRIVER".sh
 
   - composer install
 
-  # Start a webserver for web fixtures. Force using PHP 5.6 to be able to run it on PHP 5.3 and HHVM jobs too
-  - MINK_PHP_BIN=~/.phpenv/versions/5.6/bin/php vendor/bin/mink-test-server > /dev/null 2>&1 &
+  # Start a webserver for web fixtures.
+  - vendor/bin/mink-test-server > /dev/null 2>&1 &
 
 script: phpunit -v --coverage-clover=coverage.clover
 


### PR DESCRIPTION
- remove testing on HHVM, as they stopped caring about PHP compat
- use the precise infra to run tests on PHP 5.3 (until we drop support, which is not the goal here)
- add testing on PHP 7.2
- use the tested PHP version to run the builtin webserver, as the Trusty infra may not pre-install PHP 5.6 (except for the 5.3 job of course, but that one runs on Precise)