### PR TITLE
Fix the test about setting invalid timeout

### DIFF
--- a/tests/Custom/TimeoutTest.php
+++ b/tests/Custom/TimeoutTest.php
@@ -11,6 +11,8 @@ class TimeoutTest extends TestCase
      */
     public function testInvalidTimeoutSettingThrowsException()
     {
+        $this->getSession()->start();
+
         $this->getSession()->getDriver()->setTimeouts(array('invalid' => 0));
     }
 


### PR DESCRIPTION
If the session is not started, the timeout is not applied on the webdriver session (as it does not exist at that point). Failures happen only when applying the timeout on the session.

That's a test I missed in #278 when fixing other tests which were dependant on the implicit start during `getSession()`