### PR TITLE
Improve the timeout handling

### DIFF
--- a/src/Selenium2Driver.php
+++ b/src/Selenium2Driver.php
@@ -298,15 +298,13 @@ class Selenium2Driver extends CoreDriver
     {
         try {
             $this->wdSession = $this->webDriver->session($this->browserName, $this->desiredCapabilities);
-            $this->applyTimeouts();
         } catch (\Exception $e) {
             throw new DriverException('Could not open connection: '.$e->getMessage(), 0, $e);
         }
 
-        if (!$this->wdSession) {
-            throw new DriverException('Could not connect to a Selenium 2 / WebDriver server');
-        }
         $this->started = true;
+
+        $this->applyTimeouts();
     }
 
     /**

--- a/tests/Custom/TimeoutTest.php
+++ b/tests/Custom/TimeoutTest.php
@@ -6,6 +6,21 @@ use Behat\Mink\Tests\Driver\TestCase;
 
 class TimeoutTest extends TestCase
 {
+    protected function tearDown()
+    {
+        $session = $this->getSession();
+
+        // Stop the session instead of only resetting it, as timeouts are not reset (they are configuring the session itself)
+        if ($session->isStarted()) {
+            $session->stop();
+        }
+
+        // Reset the array of timeouts to avoid impacting other tests
+        $session->getDriver()->setTimeouts(array());
+
+        parent::tearDown();
+    }
+
     /**
      * @expectedException \Behat\Mink\Exception\DriverException
      */


### PR DESCRIPTION
The first commit improves the isolation for timeout tests, to avoid impacting other tests (this is especially noticeable when they break, as they were breaking next tests as well by keeping the timeouts)

The second commit improves the way we handle the started state vs applying timeouts, to avoid leaking webdriver sessions (which would not close the browser).