### PR TITLE
Fix the configuration of the PHP 5.3 job on precise

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,8 @@ cache:
 php: [5.4, 5.5, 5.6, 7.0, 7.1, 7.2]
 
 env:
-  - WEBDRIVER=selenium
+  global:
+    - WEBDRIVER=selenium
 
 matrix:
   fast_finish: true


### PR DESCRIPTION
Env variables defined as matrix are not merged with the job env variables of the matrix. We need to use global env variables (which we can still override in a specific job if needed).

This fixes this error: https://travis-ci.org/minkphp/MinkSelenium2Driver/jobs/436675862#L167