### PR TITLE
Use chrome on Travis rather than Firefox for most jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,22 +11,24 @@ php: [5.4, 5.5, 5.6, 7.0, 7.1, 7.2]
 env:
   global:
     - WEBDRIVER=selenium
+    - WEB_FIXTURES_BROWSER=chrome
 
 matrix:
   fast_finish: true
   include:
     - php: 7.0
-      env: WEBDRIVER=selenium-remote
+      env: WEBDRIVER=selenium-remote WEB_FIXTURES_BROWSER=firefox
       sudo: required
       services:
         - docker
     - php: 5.3
       dist: precise
       # Force using PHP 5.6 for the test server as PHP 5.3 does not have the builtin webserver
-      env: MINK_PHP_BIN=~/.phpenv/versions/5.6/bin/php
+      # Use Selenium 2 and Firefox when running on the precise infra, as it has a version of Firefox old enough.
+      env: MINK_PHP_BIN=~/.phpenv/versions/5.6/bin/php SELENIUM_VERSION=2 WEB_FIXTURES_BROWSER=firefox
 
 before_script:
-  - sh bin/run-"$WEBDRIVER".sh
+  - bash bin/run-"$WEBDRIVER".sh
 
   - composer install
 

--- a/bin/run-selenium.sh
+++ b/bin/run-selenium.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 set -e
 
 echo '    Starting XVFB'
@@ -6,6 +6,12 @@ sh -e /etc/init.d/xvfb start
 export DISPLAY=:99.0
 
 echo '    Downloading selenium'
-curl -L http://selenium-release.storage.googleapis.com/2.52/selenium-server-standalone-2.52.0.jar > selenium.jar
+if [ "${SELENIUM_VERSION:-3}" = "2" ]; then
+    curl -L http://selenium-release.storage.googleapis.com/2.53/selenium-server-standalone-2.53.0.jar > selenium.jar
+else
+    curl -L https://selenium-release.storage.googleapis.com/3.14/selenium-server-standalone-3.14.0.jar > selenium.jar
+fi;
+curl -L -O https://chromedriver.storage.googleapis.com/2.42/chromedriver_linux64.zip
+unzip chromedriver_linux64.zip
 echo '    Running selenium'
-java -jar selenium.jar -log /tmp/webdriver.log > /tmp/webdriver_output.txt 2>&1 &
+java -Dwebdriver.chrome.driver="$PWD/chromedriver" -jar selenium.jar -log /tmp/webdriver.log > /tmp/webdriver_output.txt 2>&1 &


### PR DESCRIPTION
On Trusty, the preinstalled Firefox version is newer than the latest version supported by the FirefoxDriver of Selenium 2, and requires using the W3C protocol. But we don't support this protocol yet.

Replaces #290 