### PR TITLE
Keep the chromeOptions array from configuration (w3c options)

### DIFF
--- a/src/Selenium2Driver.php
+++ b/src/Selenium2Driver.php
@@ -131,7 +131,7 @@ class Selenium2Driver extends CoreDriver
         // See https://sites.google.com/a/chromium.org/chromedriver/capabilities
         if (isset($desiredCapabilities['chrome'])) {
 
-            $chromeOptions = (isset($desiredCapabilities['chromeOptions']) && is_array($desiredCapabilities['chromeOptions']))? $desiredCapabilities['chromeOptions']:array();
+            $chromeOptions = (isset($desiredCapabilities['goog:chromeOptions']) && is_array($desiredCapabilities['goog:chromeOptions']))? $desiredCapabilities['goog:chromeOptions']:array();
 
             foreach ($desiredCapabilities['chrome'] as $capability => $value) {
                 if ($capability == 'switches') {

--- a/src/Selenium2Driver.php
+++ b/src/Selenium2Driver.php
@@ -131,7 +131,7 @@ class Selenium2Driver extends CoreDriver
         // See https://sites.google.com/a/chromium.org/chromedriver/capabilities
         if (isset($desiredCapabilities['chrome'])) {
 
-            $chromeOptions = array();
+            $chromeOptions = (isset($desiredCapabilities['chromeOptions']) && is_array($desiredCapabilities['chromeOptions']))? $desiredCapabilities['chromeOptions']:array();
 
             foreach ($desiredCapabilities['chrome'] as $capability => $value) {
                 if ($capability == 'switches') {


### PR DESCRIPTION
In relation with the issue #293, this change allow keep in the array chrome capabilites all options set into the behat configuration (key `default.extensions.Behat\MinkExtension.sessions.selenium2.capabilities.extra_capabilities.chromeOptions`)

Now if you set this option:
```
  extensions:
    Behat\MinkExtension:
      selenium2:
         capabilities: { "browser": "chrome", "browserName": "chrome", "extra_capabilities": { "chromeOptions": { "w3c": false } } }
```

The option will be send for the session option with ChromeDriver 75.0.3770.8+