### PR TITLE
Added missing exception catch

### DIFF
--- a/src/Selenium2Driver.php
+++ b/src/Selenium2Driver.php
@@ -794,6 +794,8 @@ JS;
             $this->wdSession->moveto(array('element' => $element->getID()));
         } catch (UnknownCommand $e) {
             // If the Webdriver implementation does not support moveto (which is not part of the W3C WebDriver spec), proceed to the click
+        } catch (UnknownError $e) {
+            
         }
 
         $element->click();


### PR DESCRIPTION
With chromedriver 81, clicking on links falls into `wdsession->moveto` which throws `UnknownError`