### PR TITLE
Only wait when necessary

### DIFF
--- a/src/Selenium2Driver.php
+++ b/src/Selenium2Driver.php
@@ -978,8 +978,11 @@ JS;
 
         do {
             $result = $this->wdSession->execute(array('script' => $script, 'args' => array()));
-            !$result && usleep(10000);
-        } while (!$result && microtime(true) < $end);
+            if ($result) {
+              break;
+            }
+            usleep(10000);
+        } while (microtime(true) < $end);
 
         return (bool) $result;
     }

--- a/src/Selenium2Driver.php
+++ b/src/Selenium2Driver.php
@@ -978,8 +978,8 @@ JS;
 
         do {
             $result = $this->wdSession->execute(array('script' => $script, 'args' => array()));
-            usleep(10000);
-        } while (microtime(true) < $end && !$result);
+            !$result && usleep(10000);
+        } while (!$result && microtime(true) < $end);
 
         return (bool) $result;
     }


### PR DESCRIPTION
In \Behat\Mink\Driver\Selenium2Driver::wait we always wait even if the condition returns true. This results in unnecessary waiting.