### PR TITLE
Fix getText() to work with elements outside viewport

### DIFF
--- a/src/Selenium2Driver.php
+++ b/src/Selenium2Driver.php
@@ -539,8 +539,7 @@ class Selenium2Driver extends CoreDriver
      */
     public function getText($xpath)
     {
-        $node = $this->findElement($xpath);
-        $text = $node->text();
+        $text = $this->executeJsOnXpath($xpath, 'return {{ELEMENT}}.innerText;');
         $text = (string) str_replace(array("\r", "\r\n", "\n"), ' ', $text);
 
         return $text;


### PR DESCRIPTION
Original impl. using `$element->text()` is defined as "Returns the visible text for the element." [1].

This PR fixes the implementation to make`getText()` working with elements outside viewport. The new impl. is inspired by `getHtml()` method defined a few lines below. Thus this fix should be consistent and there should be no downside.

See https://github.com/atk4/ui/pull/1538 - when small window (like 1280x720) is given, the tests fail with the original implementation. With this PR, the issue is fixed.

[1] https://github.com/instaclick/php-webdriver/blob/v1.0.8/lib/WebDriver/Element.php#L33