### PR TITLE
avoid passing null to strtolower

### DIFF
--- a/src/Selenium2Driver.php
+++ b/src/Selenium2Driver.php
@@ -579,7 +579,7 @@ class Selenium2Driver extends CoreDriver
     {
         $element = $this->findElement($xpath);
         $elementName = strtolower($element->name());
-        $elementType = strtolower($element->attribute('type'));
+        $elementType = strtolower($element->attribute('type') ?: '');
 
         // Getting the value of a checkbox returns its value if selected.
         if ('input' === $elementName && 'checkbox' === $elementType) {


### PR DESCRIPTION
Calling `$element->attribute('type')` on an `<option>` element returns `null`, passing `null` to `strtolower` triggers a PHP error.
Frankly, I don't know why this started to fail all of the sudden in our test suite. I'm guessing it's due to a different selenium version, but this fixes it. (`$elementType` is not used in the case of a `<select>` element).