### PR TITLE
Enable xDebug 3 support during build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ before_script:
   - until $(echo | nc localhost 8002); do sleep 1; echo waiting for PHP server on port 8002...; done; echo "PHP server started"
 
 script:
-  - ./vendor/bin/phpunit -v --coverage-clover=coverage.clover
+  - XDEBUG_MODE=coverage ./vendor/bin/phpunit -v --coverage-clover=coverage.clover
 
 after_script:
   - wget https://scrutinizer-ci.com/ocular.phar


### PR DESCRIPTION
Fixing issue with xDebug 3 (used on PHP 7.3 and PHP 7.4) build fails due coverage collection not enabled in the xDebug.