### PR TITLE
Fix StaleElementException in setValue when input has gone away

### DIFF
--- a/src/Selenium2Driver.php
+++ b/src/Selenium2Driver.php
@@ -709,22 +709,13 @@ if (document.activeElement === node) {
 }
 JS;
 
-        // In some very rare edge cases, a developer might have implemented some
-        // functionality whereby entering a specific value could cause the field
-        // to be detached from the DOM.
-        //
-        // e.g. a 2FA input field that immediately recognizes the correct value
-        // as it is typed, and causes the SPA to update the page instantly.
-        //
-        // If that happens, we will get a StaleElementReference exception when
-        // we try to execute JS on it. As such, we catch that condition here and
-        // ignore it since an element is obviously no longer focused if it is
-        // no longer attached to the page document.
+        // Cover case, when an element was removed from DOM after its value was
+        // changed (e.g. by a JavaScript of a SPA) and therefore can't be focused.
         try {
             $this->executeJsOnElement($element, $script);
         } catch (StaleElementReference $e) {
-            // Do nothing. The element is no longer attached to the page document
-            // and therefore is no longer focused (nor can it be blurred).
+            // Do nothing because an element was already removed and therefore
+            // blurring is not needed.
         }
     }
 


### PR DESCRIPTION
## Problem
Some websites using a SPA approach have implemented behavior where when a correct value is entered into an input, it is immediately recognized and the SPA updates instantly, causing the input to be detached from the DOM.

e.g. a 2FA input field that immediately recognizes the correct value as it is typed, and causes the SPA to update the page instantly if it is correct.

When this happens, the input is set correctly via the `$element->postValue()` call from `setValue()`, but when it then proceeds to call `$this->executeJsOnElement()`, a StaleElementException is thrown because the input is no longer attached to the DOM.

## Fix
Catch and swallow the exception.

## Rationale
It is not possible to execute JS on an element that is detached from the DOM, so it is impossible to attempt to unfocus it at this point (at least by executing JS on it).

The goal is to unfocus the element, which if it is detached from the DOM, it is clearly unfocused at this point.