### PR TITLE
Fix NavigationTest::testLinks on PHP 7.1

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,6 +35,8 @@ jobs:
           coverage: "none"
           php-version: "${{ matrix.php }}"
           tools: composer
+          # PHP 7.1 development web server segfaults if timezone not set.
+          ini-values: date.timezone=Europe/Paris, error_reporting=-1, display_errors=On
 
       - name: Configure for PHP >= 7.1
         if: "${{ matrix.php >= '7.1' }}"
@@ -46,8 +48,10 @@ jobs:
           composer update --no-interaction --prefer-dist
 
       - name: Setup Mink test server
+        # PHP 7.1 development web server segfaults if USE_ZEND_ALLOC not set to 0.
         run: |
           mkdir ./logs
+          export USE_ZEND_ALLOC=0
           ./vendor/bin/mink-test-server &> ./logs/mink-test-server.log &
 
       - name: Start Selenium

--- a/tests/Selenium2Config.php
+++ b/tests/Selenium2Config.php
@@ -42,15 +42,6 @@ class Selenium2Config extends AbstractConfig
             return 'Maximizing the window does not work when running the browser in Xvfb.';
         }
 
-        if (
-            'Behat\Mink\Tests\Driver\Basic\NavigationTest' === $testCase
-            && (0 === strpos($test, 'testLinks'))
-            && 'true' === getenv('GITHUB_ACTIONS')
-            && '7.1' === getenv('MATRIX_PHP')
-        ) {
-            return 'Skipping basic NavigationTest::testLinks on PHP 7.1';
-        }
-
         return parent::skipMessage($testCase, $test);
     }
 


### PR DESCRIPTION
This fixes a segfault that occurs on PHP 7.1 when date.timezone is not configured.

In testing this has not proved enough because another segfault occurs in \Behat\Mink\Tests\Driver\Form\GeneralTest::testBasicForm() after running NavigationTest::testLinks(). What's really odd is if you run them the other way around it works just fine.