### PR TITLE
No WebDriver\Session::moveto() call when dragging onto itself

### DIFF
--- a/src/Selenium2Driver.php
+++ b/src/Selenium2Driver.php
@@ -981,9 +981,11 @@ JS;
         $this->executeJsOnElement($source, $script);
 
         $this->getWebDriverSession()->buttondown();
-        $this->getWebDriverSession()->moveto(array(
-            'element' => $destination->getID()
-        ));
+        if ($destination->getID() !== $source->getID()) {
+            $this->getWebDriverSession()->moveto(array(
+                'element' => $destination->getID()
+            ));
+        }
         $this->getWebDriverSession()->buttonup();
 
         $script = <<<JS

--- a/src/Selenium2Driver.php
+++ b/src/Selenium2Driver.php
@@ -978,7 +978,7 @@ JS;
     element.dispatchEvent(event);
 }({{ELEMENT}}));
 JS;
-        $this->withSyn()->executeJsOnElement($source, $script);
+        $this->executeJsOnElement($source, $script);
 
         $this->getWebDriverSession()->buttondown();
         $this->getWebDriverSession()->moveto(array(
@@ -996,7 +996,7 @@ JS;
     element.dispatchEvent(event);
 }({{ELEMENT}}));
 JS;
-        $this->withSyn()->executeJsOnElement($destination, $script);
+        $this->executeJsOnElement($destination, $script);
     }
 
     public function executeScript(string $script)


### PR DESCRIPTION
This fixes dragging over itself, ie. source element = destination element, in such usecase, extra `WebDriver\Session::moveto()` call is redundant.

Drag library like https://github.com/Shopify/draggable needs this fix as the source element is very often transformed when dragging and `WebDriver\Session::moveto()` is failing otherwise.

![image](https://user-images.githubusercontent.com/2228672/196165988-a109c698-8714-4f95-aab9-c13b31bef15e.png)

also remove `Selenium2Driver::withSyn()` call as completely useless for dragging, the current impl. of `Selenium2Driver::dragTo()` does not use it