### PR TITLE
bug: Click on an element throws a CurlExec

### DIFF
--- a/src/Selenium2Driver.php
+++ b/src/Selenium2Driver.php
@@ -19,6 +19,7 @@ use WebDriver\Exception\UnknownCommand;
 use WebDriver\Exception\UnknownError;
 use WebDriver\Key;
 use WebDriver\WebDriver;
+use WebDriver\Exception\CurlExec;
 
 /**
  * Selenium2 driver.
@@ -800,7 +801,9 @@ JS;
             // If the Webdriver implementation does not support moveto (which is not part of the W3C WebDriver spec), proceed to the click
         } catch (UnknownError $e) {
             // Chromium driver sends back UnknownError (WebDriver\Exception with code 13)
-        }
+        } catch (CurlExec $e) {
+           // The implementation of moveto in the ChromeDriver is buggy and can throw a CurlExec exception
+        } 
 
         $element->click();
     }


### PR DESCRIPTION
When using the driver, I had the following error while clicking on an object : 

````
 Webdriver http error: 404, payload :{
        "value": {
          "error": "unknown command",
          "message": "POST \u002fsession\u002f864da5597eb3e2e3e046e799f7893967\u002fmoveto\nBuild info: version: '4.8.0', revision: '267030adea'\nSystem info: os.name: 'Linux', os.arch: 'amd64', os.version: '5.4.0-137-generic', java.version: '11.0.17'\nDriver info: driver.version: unknown",
          "stacktrace": "org.openqa.selenium.UnsupportedCommandException: POST \u002fsession\u002f864da5597eb3e2e3e046e799f7893967\u002fmoveto\nBuild info: version: '4.8.0', revision: '267030adea'\nSystem info: os.name: 'Linux', os.arch: 'amd64', os.version: '5.4.0-137-generic', java.version: '11.0.17'\nDriver info: driver.version: unknown\n\tat org.openqa.selenium.remote.codec.AbstractHttpCommandCodec.decode(AbstractHttpCommandCodec.java:293)\n\tat org.openqa.selenium.remote.codec.AbstractHttpCommandCodec.decode(AbstractHttpCommandCodec.java:122)\n\tat org.openqa.selenium.grid.web.ProtocolConverter.execute(ProtocolConverter.java:123)\n\tat org.openqa.selenium.grid (WebDriver\Exception\CurlExec)
 ````
 
 My implementation is the following : 
 * PHP 7.4
 * Symfony 4.4
 * Nginx
 * Server selenium using `selenium/standalone-chrome:latest`