### PR TITLE
Iframe switch - Send element info as selenium 4 require it

### DIFF
--- a/src/Selenium2Driver.php
+++ b/src/Selenium2Driver.php
@@ -430,7 +430,7 @@ class Selenium2Driver extends CoreDriver
           ];
         }
         else {
-          $element_info = NULL;
+          $element_info = null;
         }
 
         $this->wdSession->frame(array('id' => $element_info));

--- a/src/Selenium2Driver.php
+++ b/src/Selenium2Driver.php
@@ -424,7 +424,7 @@ class Selenium2Driver extends CoreDriver
     public function switchToIFrame($name = null)
     {
         if (!empty($name)) {
-          $element = $this->wdSession->element('id', $name);
+          $element = $this->wdSession->element('name', $name);
           $element_info = [
             'ELEMENT' => $element->getID(),
           ];

--- a/src/Selenium2Driver.php
+++ b/src/Selenium2Driver.php
@@ -423,7 +423,17 @@ class Selenium2Driver extends CoreDriver
      */
     public function switchToIFrame($name = null)
     {
-        $this->wdSession->frame(array('id' => $name));
+        if (!empty($name)) {
+          $element = $this->wdSession->element('id', $name);
+          $element_info = [
+            'ELEMENT' => $element->getID(),
+          ];
+        }
+        else {
+          $element_info = NULL;
+        }
+
+        $this->wdSession->frame(array('id' => $element_info));
     }
 
     /**


### PR DESCRIPTION
## Problem

When I try to switch to an iframe with the switchToIframe method I receive the following error:

```bash
invalid argument: 'id' can not be string
```
## Steps to reproduce

Call the method 'switchToIframe' method of the Selenium2DriverClass passing the 'id' of the iframe it is needed to switch to as a string:

```
  $driver->switchToIframe('iframe-id');
```


## Proposed resolution
According to the [current specs](https://www.w3.org/TR/webdriver1/#switch-to-frame) , it must be an object that contains the element ID inside. So, in the switchToIframe method, we must change the format to send the element ID (UUID) of the element we are switching to, instead of the plain id passed by arguments. When the name of the iframe passed is null, we must send nothing.

Currently, this solution makes the library not compatible with selenium 3, but as far as I understand selenium 4 is stable so it should be replaced.