### PR TITLE
Use "innerText" attribute in getText() method

### DIFF
--- a/src/Selenium2Driver.php
+++ b/src/Selenium2Driver.php
@@ -538,8 +538,8 @@ class Selenium2Driver extends CoreDriver
     public function getText($xpath)
     {
         $node = $this->findElement($xpath);
-        $text = $node->text();
-        $text = (string) str_replace(array("\r", "\r\n", "\n"), ' ', $text);
+        $text = $node->attribute('innerText');
+        $text = trim(preg_replace('/\s+/u', ' ', $text), ' ');
 
         return $text;
     }

--- a/src/Selenium2Driver.php
+++ b/src/Selenium2Driver.php
@@ -539,7 +539,7 @@ class Selenium2Driver extends CoreDriver
     {
         $node = $this->findElement($xpath);
         $text = $node->attribute('innerText');
-        $text = trim(preg_replace('/\s+/u', ' ', $text), ' ');
+        $text = (string) str_replace(array("\r", "\r\n", "\n"), ' ', $text);
 
         return $text;
     }


### PR DESCRIPTION
Hi, we recently moved the tests of our Drupal site from using [chrome-mink-driver](https://gitlab.com/behat-chrome/chrome-mink-driver) to `MinkSelenium2Driver` and noticing some of the tests are failing due to an empty string being returned when trying to assert the title of the page.

We found a similar issue here https://github.com/minkphp/MinkSelenium2Driver/issues/193 and it seems to be an upstream issue with Selenium? 

It also lead us to this [stackoverflow answer](https://stackoverflow.com/questions/20888592/gettext-method-of-selenium-chrome-driver-sometimes-returns-an-empty-string#answer-20963084) and which recommends to use `innerText` attribute to retrieve the text of the element.

Similar issue reported on [Drupal.org](https://www.drupal.org/project/drupal/issues/3025845)