### PR TITLE
Fix syn.js v0.15.0 input event to be synchronous

### DIFF
--- a/src/Resources/syn.js
+++ b/src/Resources/syn.js
@@ -2382,11 +2382,11 @@ define('syn/key', [
                 element = defaultResult;
             }
             if (defaultResult !== null) {
+                if (key === '\r' && element.nodeName.toLowerCase() === 'input') {
+                } else if (syn.support.oninput) {
+                    syn.trigger(element, 'input', syn.key.options(key, 'input'));
+                }
                 syn.schedule(function () {
-                    if (key === '\r' && element.nodeName.toLowerCase() === 'input') {
-                    } else if (syn.support.oninput) {
-                        syn.trigger(element, 'input', syn.key.options(key, 'input'));
-                    }
                     syn.trigger(element, 'keyup', syn.key.options(key, 'keyup'));
                     callback(runDefaults, element);
                 }, 1);


### PR DESCRIPTION
based on https://github.com/bitovi/syn/pull/196, fixes https://github.com/bitovi/syn/issues/120

input event must be synchronous per spec - https://w3c.github.io/uievents/#event-type-input

repro case: https://github.com/bitovi/syn/issues/120#issuecomment-1529794347