### PR TITLE
Add the possibility to trigger a CI run manually

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,6 +3,7 @@ name: CI
 on:
   push:
   pull_request:
+  workflow_dispatch:
 
 env:
   DRIVER_URL: "http://localhost:4444/wd/hub"


### PR DESCRIPTION
this is useful if we want to try a new version of the driver testsuite with the driver.