### PR TITLE
Allow specify frame index in the "switchToIFrame" driver method

### DIFF
--- a/src/Selenium2Driver.php
+++ b/src/Selenium2Driver.php
@@ -428,7 +428,7 @@ class Selenium2Driver extends CoreDriver
         $this->getWebDriverSession()->focusWindow($name ?: '');
     }
 
-    public function switchToIFrame(?string $name = null)
+    public function switchToIFrame($name = null)
     {
         $this->getWebDriverSession()->frame(array('id' => $name));
     }


### PR DESCRIPTION
See https://github.com/minkphp/Mink/issues/866 (PR 3 of 4)

---

If the https://github.com/minkphp/MinkSelenium2Driver/pull/382 happens to be merged before this PR, then we need to:

1. rebase this PR on top of `master` branch;
2. replace the `if ($name) {` line in the `\Behat\Mink\Driver\Selenium2Driver::switchToIFrame` method with the `if ($name && !is_int($name)) {` line.