### PR TITLE
Fixed frame switching by name on Selenium 3

### DIFF
--- a/src/Selenium2Driver.php
+++ b/src/Selenium2Driver.php
@@ -437,7 +437,45 @@ class Selenium2Driver extends CoreDriver
 
     public function switchToIFrame(?string $name = null)
     {
-        $this->getWebDriverSession()->frame(array('id' => $name));
+        $frameQuery = $name;
+
+        if ($name) {
+            try {
+                $frameQuery = $this->getWebDriverSession()->element('id', $name);
+            } catch (NoSuchElement $e) {
+                $frameQuery = $this->getWebDriverSession()->element('name', $name);
+            }
+
+            $frameQuery = $this->serializeWebElement($frameQuery);
+        }
+
+        $this->getWebDriverSession()->frame(array('id' => $frameQuery));
+    }
+
+    /**
+     * Serialize an Web Element
+     *
+     * @param Element $webElement Web webElement.
+     *
+     * @return array
+     * @todo   Remove once the https://github.com/instaclick/php-webdriver/issues/131 is fixed.
+     */
+    private function serializeWebElement(Element $webElement)
+    {
+        // Code for WebDriver 2.x version.
+        if (class_exists('\WebDriver\LegacyElement') && \defined('\WebDriver\Element::WEB_ELEMENT_ID')) {
+            if ($webElement instanceof \WebDriver\LegacyElement) {
+                return array(\WebDriver\LegacyElement::LEGACY_ELEMENT_ID => $webElement->getID());
+            }
+
+            return array(Element::WEB_ELEMENT_ID => $webElement->getID());
+        }
+
+        // Code for WebDriver 1.x version.
+        return array(
+            \WebDriver\Container::WEBDRIVER_ELEMENT_ID => $webElement->getID(),
+            \WebDriver\Container::LEGACY_ELEMENT_ID => $webElement->getID(),
+        );
     }
 
     public function setCookie(string $name, ?string $value = null)


### PR DESCRIPTION
Fixes this error from the https://github.com/minkphp/MinkSelenium2Driver/pull/383:

```
Behat\Mink\Tests\Driver\Basic\IFrameTest::testIFrame
WebDriver\Exception\InvalidArgument: data did not match any variant of untagged enum FrameId at line 3 column 1
Build info: version: '3.141.59', revision: 'e82be7d358', time: '2018-11-14T08:25:53'
System info: host: 'fv-az779-213', ip: '10.1.0.12', os.name: 'Linux', os.arch: 'amd64', os.version: '5.15.0-1056-azure', java.version: '1.8.0_[29](https://github.com/minkphp/MinkSelenium2Driver/actions/runs/8015977437/job/21897049622?pr=383#step:8:30)2'
Driver info: driver.version: unknown
```

Implementation ported from the https://github.com/minkphp/webdriver-classic-driver.

It appears, that on Selenium 3 frame switching is possible only by index or WebElement. This PR implements the later approach. In Selenium 2 frame switching by its name/id was also supported.

Additionally, the build script was updated to run tests on Selenium 3 in addition to Selenium 2. Should I split the build script change into a separate PR?