### PR TITLE
Fixing window switching on Selenium 3

### DIFF
--- a/src/Selenium2Driver.php
+++ b/src/Selenium2Driver.php
@@ -410,7 +410,20 @@ class Selenium2Driver extends CoreDriver
 
     public function reset()
     {
-        $this->getWebDriverSession()->deleteAllCookies();
+        $webDriverSession = $this->getWebDriverSession();
+
+        // Close all windows except the initial one.
+        foreach ($webDriverSession->window_handles() as $windowHandle) {
+            if ($windowHandle === $this->initialWindowHandle) {
+                continue;
+            }
+
+            $webDriverSession->focusWindow($windowHandle);
+            $webDriverSession->deleteWindow();
+        }
+
+        $this->switchToWindow();
+        $webDriverSession->deleteAllCookies();
     }
 
     public function visit(string $url)

--- a/src/Selenium2Driver.php
+++ b/src/Selenium2Driver.php
@@ -453,11 +453,11 @@ class Selenium2Driver extends CoreDriver
 
     public function switchToWindow(?string $name = null)
     {
-        $name = $name === null
+        $handle = $name === null
             ? $this->initialWindowHandle
             : $this->getWindowHandleFromName($name);
 
-        $this->getWebDriverSession()->focusWindow($name);
+        $this->getWebDriverSession()->focusWindow($handle);
     }
 
     /**


### PR DESCRIPTION
Fixes this error from the https://github.com/minkphp/MinkSelenium2Driver/pull/383:

```
Behat\Mink\Tests\Driver\Js\WindowTest::testWindow
WebDriver\Exception\NoSuchWindow: Unable to locate window:
Build info: version: '3.141.59', revision: 'e82be7d358', time: '2018-11-14T08:25:53'
System info: host: 'fv-az697-197', ip: '10.1.0.44', os.name: 'Linux', os.arch: 'amd64', os.version: '5.15.0-10[56](https://github.com/minkphp/MinkSelenium2Driver/actions/runs/8015977437/job/21897049068?pr=383#step:8:57)-azure', java.version: '1.8.0_292'
Driver info: driver.version: unknown
```

Implementation ported from the https://github.com/minkphp/webdriver-classic-driver.

What's included:

1. [fixed] switching to window by name on Selenium 3
2. [fixed] window resizing and maximizing for a non-current window
3. [added] closing all, but the main window during the session reset
4. [changed] the `getWindowName` and `getWindowNames` methods to return window names instead of window handles (if the name is empty, then the handle is returned)

Related issues:

* https://github.com/minkphp/driver-testsuite/issues/94
* https://github.com/minkphp/driver-testsuite/pull/96