### PR TITLE
Correct usage example in the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,16 +17,19 @@ use Behat\Mink\Mink,
     Behat\Mink\Session,
     Behat\Mink\Driver\Selenium2Driver;
 
-use Selenium\Client as SeleniumClient;
+require_once __DIR__ . '/vendor/autoload.php';
 
-$browser = 'firefox';
+$browserName = 'firefox';
 $url = 'http://example.com';
 
 $mink = new Mink(array(
-    'selenium2' => new Session(new Selenium2Driver($browser, null, $url)),
+    'selenium2' => new Session(new Selenium2Driver($browserName)),
 ));
 
-$mink->getSession('selenium2')->getPage()->findLink('Chat')->click();
+$session = $mink->getSession('selenium2');
+$session->visit($url);
+
+$session->getPage()->findLink('Chat')->click();
 ```
 
 Please refer to [MinkExtension-example](https://github.com/Behat/MinkExtension-example) for an executable example.


### PR DESCRIPTION
The usage example in the README.md file is quite outdated:
* it has a `Selenium\Client` class import (likely from Selenium 1 driver), that doesn't exist in this driver
* it specifies the page URL in place of the WebDriver host URL
* no page is actually opened
* the Composer autoload.php file isn't included, which results in a Fatal error

The provided example might actually be working.