### PR TITLE
Unify `browserName` given through different sources

### DIFF
--- a/src/Selenium2Driver.php
+++ b/src/Selenium2Driver.php
@@ -118,6 +118,8 @@ class Selenium2Driver extends CoreDriver
             $desiredCapabilities = array();
         }
 
+        $desiredCapabilities['browserName'] = $this->browserName;
+
         // Join $desiredCapabilities with defaultCapabilities
         $desiredCapabilities = array_replace(self::getDefaultCapabilities(), $desiredCapabilities);
 


### PR DESCRIPTION
The browser name can be specified through these places:
* the `$browserName` driver constructor argument;
* the `$desiredCapabilities['browserName']` key of the desired capabilities (either given upon driver constructor or later on).

Both browser names have no relation to each other and can lead to inconsistent driver configuration (e.g. browser name in driver set to `chrome`, but in desired capabilties set to `firefox`).

P.S.
Nobody was noticing any bugs, because `\WebDriver\WebDriver::session` method (a dependency of this project) has a polyfill code, that does the same thing as this PR.

The above-mentioned polyfill code is removed in 2.x releases of the WebDriver, which allowed to spot this problem.