### PR TITLE
dragTo should trigger mouseOver before drop

### DIFF
--- a/src/Selenium2Driver.php
+++ b/src/Selenium2Driver.php
@@ -870,6 +870,7 @@ JS;
         $this->getWebDriverSession()->moveto(array(
             'element' => $destination->getID()
         ));
+        $this->mouseOver($destinationXpath);
         $this->getWebDriverSession()->buttonup();
 
         $script = <<<JS

--- a/src/Selenium2Driver.php
+++ b/src/Selenium2Driver.php
@@ -883,6 +883,8 @@ JS;
     element.dispatchEvent(event);
 }({{ELEMENT}}));
 JS;
+        // Re-fetch destination in case mouseOver would make it stale.
+        $destination = $this->findElement($destinationXpath);
         $this->withSyn()->executeJsOnElement($destination, $script);
     }
 


### PR DESCRIPTION
Just fiddled with the Drag n Drop testing and came across an issue when testing it with ExtJs e.g. https://docs.sencha.com/extjs/4.2.2/extjs-build/examples/tree/custom-drop-logic.html
Dragging works fine - but dropping runs into nothing because the destination event isn't "ready".
I think most dynamic libraries prepare the destination by listening to a hover event - which currently isn't triggered when dragging n droping.
However, I think the native browser behavior indeed would trigger a mouse over before a drop event.
Hence the added event before the button up.

Tested with:
```cucumber
Feature: DragNDropTest
    Scenario: DragNDropTest
        Given I go to "https://docs.sencha.com/extjs/4.2.2/extjs-build/examples/tree/custom-drop-logic.html"
        And I wait for "2" seconds
        And I drag "#treeview-1013-record-ext-record-1" to "#treeview-1017-record-ext-record-6 div"
```
Without the patch it fails, with the patch it works as expected.

---

Found that the mouseover / button up might cause the destination element to be stale.
Added a re-fetch before the final event trigger to avoid that issue.