### PR TITLE
Upgrade GitHub Actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -83,13 +83,14 @@ jobs:
           vendor/bin/phpunit -v --coverage-clover=coverage.xml
 
       - name: Upload coverage
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v4
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.xml
 
       - name: Archive logs artifacts
         if: ${{ failure() }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: logs_php-${{ matrix.php }}
           path: |


### PR DESCRIPTION
Upgrading "actions/upload-artifact" GitHub Action, because the v2 is used, which causes the build to fail https://github.com/minkphp/MinkSelenium2Driver/actions/runs/11611611936 with this message:

```
This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v2`. Learn more: https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/
```

P.S.
While I'm at it I've decided to upgrade other used GitHub Actions as well.
Test failures are not introduced by this PR.