### PR TITLE
Rewrite timeout handling code to support Selenium Server 3

### DIFF
--- a/src/Selenium2Driver.php
+++ b/src/Selenium2Driver.php
@@ -395,11 +395,11 @@ class Selenium2Driver extends CoreDriver
                 }
 
                 if ($type === 'page load' || $type === 'pageLoad') {
-                    $type = 'page';
                     @trigger_error(
                         'Using "' . $type . '" timeout type is deprecated, please use "page" instead',
                         E_USER_DEPRECATED
                     );
+                    $type = 'page';
                 }
 
                 if ($type === 'page') {

--- a/src/Selenium2Driver.php
+++ b/src/Selenium2Driver.php
@@ -412,11 +412,8 @@ class Selenium2Driver extends CoreDriver
                     $this->getWebDriverSession()->timeouts($type, $param);
                 }
             }
-        } catch (UnknownError $e) {
-            // Selenium 2.x.
-            throw new DriverException('Error setting timeout: ' . $e->getMessage(), 0, $e);
-        } catch (InvalidArgument $e) {
-            // Selenium 3.x.
+        } catch (UnknownError|InvalidArgument $e) {
+            // UnknownError (Selenium 2.x). InvalidArgument (Selenium 3.x).
             throw new DriverException('Error setting timeout: ' . $e->getMessage(), 0, $e);
         }
     }
@@ -463,11 +460,8 @@ class Selenium2Driver extends CoreDriver
     {
         try {
             $this->getWebDriverSession()->open($url);
-        } catch (Timeout $e) {
-            // The W3C compatible Selenium Server.
-            throw new DriverException('Page failed to load: ' . $e->getMessage(), 0, $e);
-        } catch (ScriptTimeout $e) {
-            // The Non-W3C compatible Selenium Server.
+        } catch (ScriptTimeout|Timeout $e) {
+            // ScriptTimeout (Selenium 2.x). Timeout (Selenium 3.x).
             throw new DriverException('Page failed to load: ' . $e->getMessage(), 0, $e);
         }
     }

--- a/src/Selenium2Driver.php
+++ b/src/Selenium2Driver.php
@@ -16,7 +16,9 @@ use Behat\Mink\Selector\Xpath\Escaper;
 use WebDriver\Element;
 use WebDriver\Exception\InvalidArgument;
 use WebDriver\Exception\NoSuchElement;
+use WebDriver\Exception\ScriptTimeout;
 use WebDriver\Exception\StaleElementReference;
+use WebDriver\Exception\Timeout;
 use WebDriver\Exception\UnknownCommand;
 use WebDriver\Exception\UnknownError;
 use WebDriver\Key;
@@ -60,6 +62,11 @@ class Selenium2Driver extends CoreDriver
      * @var Session|null
      */
     private $wdSession;
+
+    /**
+     * @var bool
+     */
+    private $isW3C = false;
 
     /**
      * The timeout configuration
@@ -343,14 +350,17 @@ class Selenium2Driver extends CoreDriver
     {
         try {
             $this->wdSession = $this->webDriver->session($this->browserName, $this->desiredCapabilities);
+
+            $status = $this->webDriver->status();
+            $this->isW3C = version_compare($status['build']['version'], '3.0.0', '>=');
+
+            $this->applyTimeouts();
+            $this->initialWindowHandle = $this->getWebDriverSession()->window_handle();
         } catch (\Exception $e) {
             throw new DriverException('Could not open connection: '.$e->getMessage(), 0, $e);
         }
 
         $this->started = true;
-
-        $this->applyTimeouts();
-        $this->initialWindowHandle = $this->getWebDriverSession()->window_handle();
     }
 
     /**
@@ -376,9 +386,25 @@ class Selenium2Driver extends CoreDriver
      */
     private function applyTimeouts(): void
     {
+        $validTimeoutTypes = array('script', 'implicit', 'page load', 'pageLoad');
+
         try {
             foreach ($this->timeouts as $type => $param) {
-                $this->getWebDriverSession()->timeouts($type, $param);
+                if (!in_array($type, $validTimeoutTypes)) {
+                    throw new DriverException('Invalid timeout type: ' . $type);
+                }
+
+                if ($type === 'page load' && $this->isW3C) {
+                    $type = 'pageLoad';
+                } elseif ($type === 'pageLoad' && !$this->isW3C) {
+                    $type = 'page load';
+                }
+
+                if ($this->isW3C) {
+                    $this->getWebDriverSession()->timeouts(array($type => $param));
+                } else {
+                    $this->getWebDriverSession()->timeouts($type, $param);
+                }
             }
         } catch (UnknownError $e) {
             // Selenium 2.x.
@@ -401,6 +427,7 @@ class Selenium2Driver extends CoreDriver
         }
 
         $this->started = false;
+        $this->isW3C = false;
         try {
             $this->wdSession->close();
         } catch (\Exception $e) {
@@ -428,7 +455,15 @@ class Selenium2Driver extends CoreDriver
 
     public function visit(string $url)
     {
-        $this->getWebDriverSession()->open($url);
+        try {
+            $this->getWebDriverSession()->open($url);
+        } catch (Timeout $e) {
+            // The W3C compatible Selenium Server.
+            throw new DriverException('Page failed to load: ' . $e->getMessage(), 0, $e);
+        } catch (ScriptTimeout $e) {
+            // The Non-W3C compatible Selenium Server.
+            throw new DriverException('Page failed to load: ' . $e->getMessage(), 0, $e);
+        }
     }
 
     public function getCurrentUrl()

--- a/src/Selenium2Driver.php
+++ b/src/Selenium2Driver.php
@@ -386,7 +386,7 @@ class Selenium2Driver extends CoreDriver
      */
     private function applyTimeouts(): void
     {
-        $validTimeoutTypes = array('script', 'implicit', 'page load', 'pageLoad');
+        $validTimeoutTypes = array('script', 'implicit', 'page', 'page load', 'pageLoad');
 
         try {
             foreach ($this->timeouts as $type => $param) {
@@ -394,10 +394,16 @@ class Selenium2Driver extends CoreDriver
                     throw new DriverException('Invalid timeout type: ' . $type);
                 }
 
-                if ($type === 'page load' && $this->isW3C) {
-                    $type = 'pageLoad';
-                } elseif ($type === 'pageLoad' && !$this->isW3C) {
-                    $type = 'page load';
+                if ($type === 'page load' || $type === 'pageLoad') {
+                    $type = 'page';
+                    @trigger_error(
+                        'Using "' . $type . '" timeout type is deprecated, please use "page" instead',
+                        E_USER_DEPRECATED
+                    );
+                }
+
+                if ($type === 'page') {
+                    $type = $this->isW3C ? 'pageLoad' : 'page load';
                 }
 
                 if ($this->isW3C) {

--- a/tests/Custom/TimeoutTest.php
+++ b/tests/Custom/TimeoutTest.php
@@ -37,6 +37,7 @@ class TimeoutTest extends TestCase
         \assert($driver instanceof Selenium2Driver);
 
         $this->expectException('\Behat\Mink\Exception\DriverException');
+        $this->expectExceptionMessage('Invalid timeout type: invalid');
         $driver->setTimeouts(array('invalid' => 0));
     }
 
@@ -69,5 +70,29 @@ class TimeoutTest extends TestCase
         $element = $session->getPage()->find('css', '#waitable > div');
 
         $this->assertNotNull($element);
+    }
+
+    /**
+     * @dataProvider shortPageLoadTimeoutThrowsExceptionDataProvider
+     */
+    public function testShortPageLoadTimeoutThrowsException(string $timeoutType)
+    {
+        $session = $this->getSession();
+        $driver = $session->getDriver();
+        \assert($driver instanceof Selenium2Driver);
+
+        $driver->setTimeouts(array($timeoutType => 1)); // Use 1ms timeout to avoid any successful page load.
+
+        $this->expectException('\Behat\Mink\Exception\DriverException');
+        $this->expectExceptionMessage('Page failed to load: ');
+        $session->visit('https://www.webpagetest.org/'); // Use external URL, because it loads slower, then local.
+    }
+
+    public static function shortPageLoadTimeoutThrowsExceptionDataProvider(): array
+    {
+        return array(
+            'w3c style' => array('pageLoad'),
+            'non-w3c style' => array('page load'),
+        );
     }
 }

--- a/tests/Custom/TimeoutTest.php
+++ b/tests/Custom/TimeoutTest.php
@@ -5,9 +5,12 @@ namespace Behat\Mink\Tests\Driver\Custom;
 use Behat\Mink\Driver\Selenium2Driver;
 use Behat\Mink\Exception\DriverException;
 use Behat\Mink\Tests\Driver\TestCase;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 
 class TimeoutTest extends TestCase
 {
+    use ExpectDeprecationTrait;
+
     /**
      * @after
      */

--- a/tests/Custom/TimeoutTest.php
+++ b/tests/Custom/TimeoutTest.php
@@ -81,11 +81,11 @@ class TimeoutTest extends TestCase
         $driver = $session->getDriver();
         \assert($driver instanceof Selenium2Driver);
 
-        $driver->setTimeouts(array($timeoutType => 1)); // Use 1ms timeout to avoid any successful page load.
+        $driver->setTimeouts(array($timeoutType => 500));
 
         $this->expectException('\Behat\Mink\Exception\DriverException');
         $this->expectExceptionMessage('Page failed to load: ');
-        $session->visit('https://www.webpagetest.org/'); // Use external URL, because it loads slower, then local.
+        $session->visit($this->pathTo('/page_load.php?sleep=2'));
     }
 
     public static function shortPageLoadTimeoutThrowsExceptionDataProvider(): array

--- a/tests/Custom/TimeoutTest.php
+++ b/tests/Custom/TimeoutTest.php
@@ -3,6 +3,7 @@
 namespace Behat\Mink\Tests\Driver\Custom;
 
 use Behat\Mink\Driver\Selenium2Driver;
+use Behat\Mink\Exception\DriverException;
 use Behat\Mink\Tests\Driver\TestCase;
 
 class TimeoutTest extends TestCase
@@ -36,7 +37,7 @@ class TimeoutTest extends TestCase
         $driver = $session->getDriver();
         \assert($driver instanceof Selenium2Driver);
 
-        $this->expectException('\Behat\Mink\Exception\DriverException');
+        $this->expectException(DriverException::class);
         $this->expectExceptionMessage('Invalid timeout type: invalid');
         $driver->setTimeouts(array('invalid' => 0));
     }
@@ -72,23 +73,38 @@ class TimeoutTest extends TestCase
         $this->assertNotNull($element);
     }
 
-    /**
-     * @dataProvider shortPageLoadTimeoutThrowsExceptionDataProvider
-     */
-    public function testShortPageLoadTimeoutThrowsException(string $timeoutType)
+    public function testShortPageLoadTimeoutThrowsException()
     {
         $session = $this->getSession();
         $driver = $session->getDriver();
         \assert($driver instanceof Selenium2Driver);
 
-        $driver->setTimeouts(array($timeoutType => 500));
+        $driver->setTimeouts(array('page' => 500));
 
-        $this->expectException('\Behat\Mink\Exception\DriverException');
+        $this->expectException(DriverException::class);
         $this->expectExceptionMessage('Page failed to load: ');
         $session->visit($this->pathTo('/page_load.php?sleep=2'));
     }
 
-    public static function shortPageLoadTimeoutThrowsExceptionDataProvider(): array
+    /**
+     * @group legacy
+     * @dataProvider deprecatedPageLoadDataProvider
+     */
+    public function testDeprecatedShortPageLoadTimeoutThrowsException(string $type)
+    {
+        $session = $this->getSession();
+        $driver = $session->getDriver();
+        \assert($driver instanceof Selenium2Driver);
+
+        $this->expectDeprecation('Using "' . $type . '" timeout type is deprecated, please use "page" instead');
+        $driver->setTimeouts(array($type => 500));
+
+        $this->expectException(DriverException::class);
+        $this->expectExceptionMessage('Page failed to load: ');
+        $session->visit($this->pathTo('/page_load.php?sleep=2'));
+    }
+
+    public static function deprecatedPageLoadDataProvider(): array
     {
         return array(
             'w3c style' => array('pageLoad'),


### PR DESCRIPTION
1. Instead of supplying developer-provided timeout type directly to the Selenium Server as-is perform some validation as done in https://github.com/minkphp/webdriver-classic-driver .
2. Wrap WebDriver's `TimeoutException` and `ScriptTimeoutException` exceptions into `DriverException`, when the page wasn't opened due to `page load`/`pageLoad` timeout being met.
3. The `pageLoad` timeout wasn't working with Google Chrome on Selenium Server 3.

Closes #397