### PR TITLE
Throw exception, when doing a "setValue" call on checkbox with a non-boolean value

### DIFF
--- a/src/Selenium2Driver.php
+++ b/src/Selenium2Driver.php
@@ -787,7 +787,11 @@ JS;
             }
 
             if ('checkbox' === $elementType) {
-                if ($element->selected() xor (bool) $value) {
+                if (!is_bool($value)) {
+                    throw new DriverException('Only boolean values can be used for a checkbox input.');
+                }
+
+                if ($element->selected() xor $value) {
                     $this->clickOnElement($element);
                 }
 


### PR DESCRIPTION
Fixes a test failure for a test, that is introduced in the https://github.com/minkphp/driver-testsuite/pull/102 .