### PR TITLE
Improve drag-and-drop JS event emulation on Selenium 3

### DIFF
--- a/src/Selenium2Driver.php
+++ b/src/Selenium2Driver.php
@@ -1008,33 +1008,31 @@ JS;
         ));
 
         $script = <<<JS
-(function (element) {
-    var event = document.createEvent("HTMLEvents");
+(function (sourceElement) {
+    window['__minkDragAndDropSourceElement'] = sourceElement;
 
-    event.initEvent("dragstart", true, true);
-    event.dataTransfer = {};
-
-    element.dispatchEvent(event);
+    sourceElement.dispatchEvent(new DragEvent('dragstart', {bubbles: true, cancelable: true}));
 }({{ELEMENT}}));
 JS;
         $this->executeJsOnElement($source, $script);
 
-        $this->getWebDriverSession()->buttondown();
-        if ($destination->getID() !== $source->getID()) {
+        if ($destination->getID() === $source->getID()) {
+            $this->getWebDriverSession()->click(0);
+        } else {
+            $this->getWebDriverSession()->buttondown();
             $this->getWebDriverSession()->moveto(array(
                 'element' => $destination->getID()
             ));
+            $this->getWebDriverSession()->buttonup();
         }
-        $this->getWebDriverSession()->buttonup();
 
         $script = <<<JS
-(function (element) {
-    var event = document.createEvent("HTMLEvents");
+(function (targetElement) {
+    targetElement.dispatchEvent(new DragEvent('dragover', {bubbles: true, cancelable: true}));
 
-    event.initEvent("drop", true, true);
-    event.dataTransfer = {};
+    targetElement.dispatchEvent(new DragEvent('drop', {bubbles: true, cancelable: true}));
 
-    element.dispatchEvent(event);
+    window['__minkDragAndDropSourceElement'].dispatchEvent(new DragEvent('dragend', {bubbles: true, cancelable: true}));
 }({{ELEMENT}}));
 JS;
         $this->executeJsOnElement($destination, $script);

--- a/src/Selenium2Driver.php
+++ b/src/Selenium2Driver.php
@@ -1029,40 +1029,24 @@ TEXT
         $target = $this->findElement($destinationXpath);
 
         $this->getWebDriverSession()->moveto(['element' => $source->getID()]);
+        $this->getWebDriverSession()->buttondown();
 
         $this->executeJsOnElement($source, <<<'JS'
             (function (sourceElement) {
-                var withPointerEvents = 'PointerEvent' in window;
                 window['__minkDragAndDropSourceElement'] = sourceElement;
 
-                withPointerEvents && sourceElement.dispatchEvent(new PointerEvent('pointerdown', {bubbles: true, cancelable: true}));
-                sourceElement.dispatchEvent(new MouseEvent('mousedown', {bubbles: true, cancelable: true}));
                 sourceElement.dispatchEvent(new DragEvent('dragstart', {bubbles: true, cancelable: true}));
-                withPointerEvents && sourceElement.dispatchEvent(new PointerEvent('pointercancel', {bubbles: true, cancelable: true}));
-                withPointerEvents && sourceElement.dispatchEvent(new PointerEvent('pointerout', {bubbles: true, cancelable: true}));
-                withPointerEvents && sourceElement.dispatchEvent(new PointerEvent('pointerleave', {bubbles: true, cancelable: true}));
             }({{ELEMENT}}));
 JS
         );
 
         $this->getWebDriverSession()->moveto(['element' => $target->getID()]);
+        $this->getWebDriverSession()->buttonup();
 
         $this->executeJsOnElement($target, <<<'JS'
             (function (targetElement) {
-                var withPointerEvents = 'PointerEvent' in window;
                 var sourceElement = window['__minkDragAndDropSourceElement'];
 
-                withPointerEvents && targetElement.dispatchEvent(new PointerEvent('pointerover', {bubbles: true, cancelable: true}));
-                withPointerEvents && targetElement.dispatchEvent(new PointerEvent('pointerenter', {bubbles: true, cancelable: true}));
-                sourceElement.dispatchEvent(new MouseEvent('mouseout', {bubbles: true, cancelable: true}));
-                sourceElement.dispatchEvent(new MouseEvent('mouseleave', {bubbles: true, cancelable: true}));
-                targetElement.dispatchEvent(new MouseEvent('mouseover', {bubbles: true, cancelable: true}));
-                targetElement.dispatchEvent(new MouseEvent('mouseenter', {bubbles: true, cancelable: true}));
-                targetElement.dispatchEvent(new MouseEvent('mousemove', {bubbles: true, cancelable: true}));
-                withPointerEvents && targetElement.dispatchEvent(new PointerEvent('pointerout', {bubbles: true, cancelable: true}));
-                withPointerEvents && targetElement.dispatchEvent(new PointerEvent('pointerleave', {bubbles: true, cancelable: true}));
-                targetElement.dispatchEvent(new MouseEvent('mouseout', {bubbles: true, cancelable: true}));
-                targetElement.dispatchEvent(new MouseEvent('mouseleave', {bubbles: true, cancelable: true}));
                 sourceElement.dispatchEvent(new DragEvent('drag', {bubbles: true, cancelable: true}));
                 targetElement.dispatchEvent(new DragEvent('dragover', {bubbles: true, cancelable: true}));
                 targetElement.dispatchEvent(new DragEvent('drop', {bubbles: true, cancelable: true}));

--- a/src/Selenium2Driver.php
+++ b/src/Selenium2Driver.php
@@ -1028,7 +1028,7 @@ TEXT
         $source = $this->findElement($sourceXpath);
         $target = $this->findElement($destinationXpath);
 
-        $this->getWebDriverSession()->moveto(['element' => $source->getID()]);
+        $this->getWebDriverSession()->moveto(array('element' => $source->getID()));
         $this->getWebDriverSession()->buttondown();
 
         $this->executeJsOnElement($source, <<<'JS'
@@ -1040,7 +1040,7 @@ TEXT
 JS
         );
 
-        $this->getWebDriverSession()->moveto(['element' => $target->getID()]);
+        $this->getWebDriverSession()->moveto(array('element' => $target->getID()));
         $this->getWebDriverSession()->buttonup();
 
         $this->executeJsOnElement($target, <<<'JS'


### PR DESCRIPTION
I'm not fully aware of the flow of running this driver with Selenium3, but [this drag and drop failure](https://github.com/minkphp/driver-testsuite/actions/runs/12835310900/job/35794483596) seemed very consistent to me, so I tried solving it.

## Investigation

I noticed the following:
- we try to simulate drag and drop by triggering javascript events
  - the way I saw it, we do not trigger the full / correct flow of events, so I fixed it - but it does not relate to Selenium 3.
- in case of drag & dropping an element onto itself, Selenium 3 had some funny stuff happening with mouse clicks - essentially it doesn't like mousedown/mouseup on an element that has been hidden.
  - ~luckily, I can just trigger click in this case, which pretty much is the same operation (since the element is not being moved - this is the selenium 3 fix.~

## In terms of code

Drag Events before:
- `dragstart` on source element
- `drop` on target element
Drag Events after (which I think should be more realistic):
- `dragstart` on source element
- `dragover` on target element
- `drop` on target element
- `dragend` on source element

Driver Mouse Events before:
- mouse `button down`
- if `sourceElement !== targetElement` mouse `move`
- mouse `button up`

Driver Mouse Events after:
- mouse `move`
- mouse `button down`
- (dragging starts)
- mouse `move`
- mouse `button up`
- (dragging ends)

I also switched to more modern javascript event construction. Not sure if we should worry about old browsers, like say MSIE. Compatibility chart: https://caniuse.com/mdn-api_dragevent_dragevent

Note that sticking to the old code has the opposite problem - it uses deprecated functionality that might break in new browsers - if we absolutely want to keep maximum compatibility, I suppose we could use a fallback ("if createEvent exists use it, else use constructor").

----

Live testing: https://jsfiddle.net/0L6kthxv/1/