### PR TITLE
Use selenium 2 as the default version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
     selenium:
-        image: ${SELENIUM_IMAGE:-selenium/standalone-chrome:4}
+        image: ${SELENIUM_IMAGE:-selenium/standalone-chrome:2}
         hostname: selenium
         shm_size: 2g
         environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
     selenium:
-        image: ${SELENIUM_IMAGE:-selenium/standalone-chrome:2}
+        image: ${SELENIUM_IMAGE:-selenium/standalone-chrome:2.53.1}
         hostname: selenium
         shm_size: 2g
         environment:


### PR DESCRIPTION
I missed this in the original PR. This driver cannot work with Selenium 4 at all, so it makes sense to use a supported default version, if for anything to avoid confusing users.