### PR TITLE
Replaced short array syntax usages with traditional array syntax

### DIFF
--- a/tests/Selenium2Config.php
+++ b/tests/Selenium2Config.php
@@ -51,9 +51,9 @@ class Selenium2Config extends AbstractConfig
 
     public function skipMessage($testCase, $test): ?string
     {
-        $testCallback = [$testCase, $test];
+        $testCallback = array($testCase, $test);
 
-        if ([Html5Test::class, 'testHtml5Types'] === $testCallback) {
+        if (array(Html5Test::class, 'testHtml5Types') === $testCallback) {
             return <<<TEXT
 WebDriver does not support setting value in color inputs.
 
@@ -80,7 +80,7 @@ TEXT;
             return 'Checking status code is not supported.';
         }
 
-        if ([JavascriptTest::class, 'testDragDropOntoHiddenItself'] === $testCallback) {
+        if (array(JavascriptTest::class, 'testDragDropOntoHiddenItself') === $testCallback) {
             $browser = $_SERVER['WEB_FIXTURES_BROWSER'] ?? null;
 
             if ($browser === 'firefox' && $this->getSeleniumMajorVersion() === 2) {
@@ -89,7 +89,7 @@ TEXT;
         }
 
         // Skip right-clicking tests, when an unsupported Selenium version detected.
-        if (([HoverTest::class, 'testRightClickHover'] === $testCallback || [EventsTest::class, 'testRightClick'] === $testCallback)
+        if ((array(HoverTest::class, 'testRightClickHover') === $testCallback || array(EventsTest::class, 'testRightClick') === $testCallback)
             && !$this->isRightClickingInSeleniumSupported()
         ) {
             return <<<TEXT
@@ -100,7 +100,7 @@ TEXT;
         }
 
         // Skips all tests, except mentioned below, for an unsupported Selenium version.
-        if ([SeleniumSupportTest::class, 'testDriverCannotBeUsedInUnsupportedSelenium'] !== $testCallback
+        if (array(SeleniumSupportTest::class, 'testDriverCannotBeUsedInUnsupportedSelenium') !== $testCallback
             && !$this->isSeleniumVersionSupported()
         ) {
             return 'Does not apply to unsupported Selenium versions.';


### PR DESCRIPTION
The short array syntax was accidentally introduced in the #407.

If there is a need, then we can mass-convert driver code to use short array syntax (e.g. using PHP_CodeSniffer rule or PhpStorm inspection).